### PR TITLE
feat(data): GraphQL contributions fetcher + parser (PR 003)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:renderer": "tsc",
     "check:feature-memory": "node scripts/check-feature-memory.mjs",
     "check:repo": "node scripts/check-static-baseline.mjs",
+    "fetch:sample": "node scripts/fetch-contributions.mjs",
     "check:html": "html-validate prototypes/variant-d-grid-peaks.html",
     "check:js": "eslint \"prototypes/**/*.html\"",
     "check:ts": "tsc --noEmit",

--- a/scripts/fetch-contributions.mjs
+++ b/scripts/fetch-contributions.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const username = process.argv[2];
+if (!username) {
+  console.error("Usage: node scripts/fetch-contributions.mjs <username>");
+  process.exit(1);
+}
+
+const token = process.env.GITHUB_TOKEN;
+if (!token) {
+  console.error("GITHUB_TOKEN env var required");
+  process.exit(1);
+}
+
+const build = spawnSync("pnpm", ["run", "build:renderer"], {
+  stdio: "inherit",
+});
+if (build.status !== 0) {
+  process.exit(build.status ?? 1);
+}
+
+const { fetchContributions } = await import("../dist-renderer/data.js");
+const days = await fetchContributions(username, token);
+
+mkdirSync("sample-out", { recursive: true });
+const outPath = `sample-out/contributions-${username}.json`;
+writeFileSync(outPath, `${JSON.stringify(days, null, 2)}\n`, "utf8");
+
+const active = days.filter((d) => d.count > 0).length;
+const max = days.reduce((m, d) => Math.max(m, d.count), 0);
+const first = days[0]?.date ?? "(none)";
+const last = days.at(-1)?.date ?? "(none)";
+console.log(
+  `wrote ${outPath} (active=${active} max=${max} first=${first} last=${last})`,
+);

--- a/specs/003-data-layer/plan.md
+++ b/specs/003-data-layer/plan.md
@@ -1,0 +1,185 @@
+# Plan — Data layer
+
+## Approach
+
+Single-phase implementation on this worktree. The surface is small and the moving parts are orthogonal: parser (pure), fetcher (I/O wrapper over parser), CLI (thin wrapper over fetcher). Unlike PR 002, there is no rendering math to eyeball — correctness is fully captured by fixture-driven unit tests. The only human-in-the-loop step is capturing the real-data fixture once, and a one-time manual smoke against live GitHub.
+
+The renderer stays frozen. PR 003 delivers a data path that the Action entrypoint (PR 004) will compose with the renderer — this PR does not compose them itself.
+
+## Why not /plan or /ralph
+
+- `/plan` interview: decisions are fixed (see spec table). No ambiguity to resolve.
+- `/ralph` loop: manual fixture capture + live smoke require human eyes; no machine-checkable "done."
+- Manual executor + one `code-reviewer` pass before push is the proven shape from PR 002 (3 cycles, 4 × P2 resolved).
+
+## Step order
+
+### Step 1 — capture and sanitize the real-data fixture
+
+Before writing any parser code, capture the exact GraphQL response shape for user `kiaquila`.
+
+1. Create a throwaway PAT with `read:user` and `public_repo` scopes (classic or fine-grained; classic is simpler).
+2. Manually issue the GraphQL query with `curl -H "Authorization: bearer $PAT" -d '{...}' https://api.github.com/graphql`, redirect to `tests/fixtures/graphql-sample.json`.
+3. Keep the full GraphQL response wrapper (`{data: {user: {contributionsCollection: {contributionCalendar: {weeks: [...]}}}}}`) so the parser sees exactly what the real API returns. The query requests no PII fields, so the response naturally contains only `weeks[].contributionDays[]` data.
+4. Verify: fixture has 53 `weeks`, flattened `contributionDays` length ≈ 371 (actual on 2026-04-21 capture: 367; GitHub truncates leading/trailing partial weeks — parser handles this without a hard-coded length).
+
+### Step 2 — `src/types.ts` extensions
+
+Add:
+
+```ts
+export interface GraphQLContributionDay {
+  readonly date: ISODate;
+  readonly contributionCount: number;
+}
+export interface GraphQLContributionWeek {
+  readonly contributionDays: readonly GraphQLContributionDay[];
+}
+export interface GraphQLContributionsResponse {
+  readonly data: {
+    readonly user: {
+      readonly contributionsCollection: {
+        readonly contributionCalendar: {
+          readonly weeks: readonly GraphQLContributionWeek[];
+        };
+      };
+    } | null;
+  };
+  readonly errors?: readonly { readonly message: string }[];
+}
+```
+
+Minimal enough to validate the path we actually read. Extra keys in the live payload are fine — TS structural typing ignores them.
+
+### Step 3 — `src/data.ts`
+
+Two exports, nothing else:
+
+```ts
+export async function fetchContributions(
+  username: string,
+  token: string,
+  opts?: FetchOptions,
+): Promise<ContributionDay[]>;
+
+export function parseContributionsResponse(payload: unknown): ContributionDay[];
+```
+
+Internals (private, file-local):
+
+- `buildQuery(username, from, to)` — returns `{ query, variables }` JSON for the POST body. Uses GraphQL variables, not string interpolation, to sidestep injection concerns (even though `username` comes from a trusted CLI arg, the pattern is right).
+- `computeWindow(now = new Date())` — returns `{ from, to }` as ISO-8601 strings, rolling 371 days ending at `now` UTC. `now` parameter is for testability; no real caller passes it.
+- Response handling in `fetchContributions`:
+  1. `fetch(endpoint, { method: 'POST', headers: {Authorization, Content-Type, Accept, User-Agent}, body })`.
+  2. Non-2xx → `throw new Error('GitHub API request failed: HTTP <status>', { cause: { status, body } })`. Special-case 403 with `x-ratelimit-remaining: '0'` to mention rate limiting in the message.
+  3. 2xx → `await response.json()`.
+  4. If `payload.errors?.length` → `throw new Error('GitHub GraphQL returned errors: <joined messages>', { cause: payload.errors })`.
+  5. If `payload.data.user === null` → `throw new Error('GitHub user not found: <username>')` (the public GraphQL endpoint returns this when the login doesn't exist).
+  6. Return `parseContributionsResponse(payload)`.
+- `parseContributionsResponse`:
+  1. Narrow-type-guard the incoming `unknown` manually (`typeof`, `Array.isArray`). No runtime schema lib.
+  2. Walk `data.user.contributionsCollection.contributionCalendar.weeks[]`, flatten `contributionDays[]` into `ContributionDay[]` with `{ date, count: contributionCount }`.
+  3. Validate each `count` is a finite integer ≥ 0; coerce `NaN` / non-integer to an error.
+  4. Return chronological order — GraphQL already returns weeks oldest-first, so flattening preserves order.
+
+No retry, no timeout arg exposed. If a live call hangs, user Ctrl-C's the CLI. (Action will add a wrapper timeout in PR 004 if needed.)
+
+### Step 4 — `scripts/fetch-contributions.mjs`
+
+```
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const username = process.argv[2];
+if (!username) { console.error("Usage: node scripts/fetch-contributions.mjs <username>"); process.exit(1); }
+const token = process.env.GITHUB_TOKEN;
+if (!token) { console.error("GITHUB_TOKEN env var required"); process.exit(1); }
+
+const build = spawnSync("pnpm", ["run", "build:renderer"], { stdio: "inherit" });
+if (build.status !== 0) process.exit(build.status);
+
+const { fetchContributions } = await import("../dist-renderer/data.js");
+const days = await fetchContributions(username, token);
+
+mkdirSync("sample-out", { recursive: true });
+const outPath = `sample-out/contributions-${username}.json`;
+writeFileSync(outPath, `${JSON.stringify(days, null, 2)}\n`, "utf8");
+
+const active = days.filter(d => d.count > 0).length;
+const max = days.reduce((m, d) => Math.max(m, d.count), 0);
+console.log(`wrote ${outPath} (active=${active} max=${max} first=${days[0].date} last=${days.at(-1).date})`);
+```
+
+Error handling: if `fetchContributions` throws, the default `unhandledRejection` prints stack and exits non-zero. Good enough; no `try/catch` adornment.
+
+### Step 5 — `tests/data.test.mjs`
+
+Structure:
+
+```
+test("parser: golden fixture → 371 days chronological")
+test("parser: empty-year payload → 371 zeros")
+test("parser: single-day-with-activity → exactly one count > 0")
+test("parser: rejects malformed payload (missing user)")
+test("parser: rejects non-integer count")
+test("fetch: POST url/headers/body shape")   // uses globalThis.fetch stub
+test("fetch: HTTP 401 throws auth-flavored error")
+test("fetch: HTTP 403 + x-ratelimit-remaining=0 mentions rate limit")
+test("fetch: top-level errors[] in 200 body throws with joined message")
+test("fetch: data.user === null throws user-not-found")
+test("fetch: determinism — parser called twice on sample returns deepEqual arrays")
+```
+
+`globalThis.fetch` is replaced per-test with a fresh stub and restored in `afterEach`. Response objects use minimal `{ ok, status, headers: new Headers({...}), json: async () => payload }` shape. No `@mswjs` or similar — Node's test runner + native fetch types are enough.
+
+Empty-year and single-day payloads are built in-test from the golden fixture by zeroing / setting specific counts — no separate fixture files.
+
+### Step 6 — package.json scripts
+
+Add:
+
+```
+"fetch:sample": "node scripts/fetch-contributions.mjs"
+```
+
+No changes to `ci` — the new test glob already picks up `tests/data.test.mjs`.
+
+### Step 7 — commit discipline
+
+Single commit on this worktree (user-approved 2026-04-21 — spec ships alongside code):
+
+- `feat(data): GraphQL contributions fetcher + parser` — `specs/003-data-layer/**`, `src/data.ts`, `src/types.ts`, `tests/data.test.mjs`, `tests/fixtures/graphql-sample.json`, `scripts/fetch-contributions.mjs`, `package.json`.
+
+## Fixture length note
+
+Real capture for user `kiaquila` on 2026-04-21 yielded **53 weeks × 7 days = 367 flattened days** (not exactly 371): GitHub's `contributionsCollection` aligns the requested window to week boundaries (weeks start Sunday), so leading/trailing partial weeks are truncated. Parser tests MUST derive expected length from the fixture itself (`fixture.weeks.flatMap(w => w.contributionDays).length`) — do not hard-code 371 anywhere.
+
+## Validation order
+
+1. Step 1 → raw fixture captured; length 371 confirmed.
+2. Steps 2–3 → `pnpm run check:ts` green.
+3. Step 4 → `GITHUB_TOKEN=<pat> node scripts/fetch-contributions.mjs kiaquila` writes `sample-out/contributions-kiaquila.json`. Summary matches expected distribution.
+4. Step 5 → `pnpm test` green; ≥ 6 new cases.
+5. Full `pnpm run ci` local green.
+6. `pnpm run check:feature-memory` green (spec folder complete).
+7. `code-reviewer` subagent pass on `src/data.ts` + tests — focus: purity, narrow type guards, error-boundary hygiene, token leak potential.
+8. `git push` → PR open → `@codex review` via gh CLI (per `feedback_codex_human_trigger` memory).
+9. Iterate on findings. Budget: 2–4 cycles for an M PR.
+
+## Risks
+
+- **Fixture drift**: real GitHub response format could change (unlikely — this endpoint has been stable for years, but possible). Mitigation: fixture is captured once; parser is resilient to extra unknown keys.
+- **Rate-limit flakiness on local smoke**: with the default 5000 req/hr authenticated limit we're nowhere near it. No mitigation needed.
+- **Token leak in CI logs**: CLI prints only `username` and summary. `fetch` errors include URL but not headers. Covered by "token is never logged" constraint; verified in code-review step.
+- **`data.user: null` vs 404**: GitHub returns 200 + `data.user: null` for missing logins, not 404. Test explicitly covers this branch.
+- **ESM import of compiled TS from `.mjs`**: PR 002 already set this up (`dist-renderer/*.js` ES modules); `scripts/render-sample.mjs` is the template, just copy its shape.
+- **Codex inline-comment pinning** (`feedback_codex_inline_pinned_to_head`): verify final verdict from Codex summary comment, not inline-comment count.
+
+## Out of bounds
+
+- No changes to `src/renderer.ts`, `src/normalize.ts`, `src/themes.ts`, `src/prng.ts`.
+- No changes to `.github/workflows/*`.
+- No changes to `prototypes/**`.
+- No changes to `docs_comet/**` — docs for the Action wiring land with PR 004 / PR 005.
+- No new lint rules, no ESLint config edits.

--- a/specs/003-data-layer/spec.md
+++ b/specs/003-data-layer/spec.md
@@ -1,0 +1,88 @@
+# Feature 003 — Data layer: GraphQL contributions fetcher + parser
+
+## Goal
+
+Add the data layer that the Action entrypoint (PR 004) will wire into the renderer (PR 002): a pure TypeScript module `src/data.ts` that fetches a user's contributions from GitHub's GraphQL API and parses the response into the flat `ContributionDay[]` array that `renderCometSVG` already consumes.
+
+## Why
+
+PR 002 delivered the renderer and five synthetic fixtures. Real-world verification has been stubbed out behind those synthetic fixtures. Before wrapping the Action shell in PR 004, we need a stand-alone data path that:
+
+- Can be tested offline against a captured GraphQL response (no network in CI),
+- Can be exercised manually against a real account (to de-risk the SVG on real-world distributions),
+- Produces output identical in shape to what the renderer already expects, so PR 004 becomes pure glue.
+
+Splitting data off from Action packaging keeps each PR within Codex's review comfort zone (historical budget: 3–6 cycles for L, cleaner for M).
+
+## Scope
+
+**In scope** (second of four PRs toward MVP Action)
+
+- `src/data.ts` — two exported functions:
+  - `fetchContributions(username: string, token: string, opts?: FetchOptions): Promise<ContributionDay[]>` — single POST to `https://api.github.com/graphql` using native Node 20 `fetch`, rolling 371-day window ending today UTC, returns parsed days in chronological order.
+  - `parseContributionsResponse(payload: unknown): ContributionDay[]` — pure parser, no network, validates the expected GraphQL shape and flattens `weeks[].contributionDays[]` into the flat array.
+- `src/types.ts` — extend with `FetchOptions` (`{ now?: Date }` — injected clock for deterministic rolling-window tests; MVP callers pass nothing). No GraphQL response types: the parser operates on `unknown` with runtime narrow-guards, so a static type would be dead documentation.
+- `scripts/fetch-contributions.mjs` — CLI wrapper that reads `GITHUB_TOKEN` from env + username from arg, runs `fetchContributions`, writes `sample-out/contributions-<username>.json` and prints a summary (`active=N max=M first=YYYY-MM-DD last=YYYY-MM-DD`). Prebuilds the renderer output so the compiled `dist-renderer/data.js` is importable.
+- `tests/data.test.mjs` — offline suite:
+  - Parser: golden fixture `tests/fixtures/graphql-sample.json` → `ContributionDay[]` with correct length, dates monotone, counts integer ≥ 0.
+  - Edge cases: empty-year payload (all counts 0), mid-week start (GitHub aligns weeks to Sunday — partial first week is still flattened correctly), single-day-with-activity.
+  - Fetch transport: `globalThis.fetch` stubbed — assert endpoint URL, `Authorization: bearer <token>`, `Content-Type: application/json`, request body includes `contributionsCollection` and the username.
+  - Error paths: HTTP 401, HTTP 403 with `x-ratelimit-remaining: 0`, top-level `errors: [...]` in a 200 body, malformed JSON response body.
+- `tests/fixtures/graphql-sample.json` — captured GraphQL payload for a real account (user `kiaquila`, own token). Full response wrapper kept (`{data: {user: {contributionsCollection: {contributionCalendar: {weeks: [...]}}}}}`) so the parser sees what the real API returns; the query intentionally does not request PII fields (login/email/avatar), so no sanitization step was necessary.
+- `package.json` script: `fetch:sample` = `node scripts/fetch-contributions.mjs`.
+
+**Out of scope** (deferred)
+
+- `action.yml`, `src/action.ts`, ncc bundle, output-branch push — PR 004.
+- Wiring `fetchContributions` → `renderCometSVG` into an end-to-end flow — PR 004.
+- `--from` / `--to` CLI flags — MVP always fetches the rolling 371-day window.
+- GitHub Enterprise host support (custom GraphQL URL) — post-MVP; the endpoint is hardcoded.
+- Octokit or any HTTP/GraphQL client dependency — native `fetch` only.
+- Retries, exponential backoff, circuit breakers — one shot, fail fast with context.
+
+## Constraints
+
+- **No runtime dependencies.** Node 20 stdlib (`fetch`, `URL`, `AbortController` if needed) only. Dev-deps unchanged beyond what PR 002 already added.
+- **Deterministic parser.** `parseContributionsResponse(sample)` returns an identical array every call — no clock, no PRNG, no iteration-order surprises.
+- **Errors on system boundary only.** Validation happens on HTTP response shape and GraphQL body; internal helpers trust inputs. Thrown errors use `Error` with a descriptive message and `cause` set to the underlying source (response body, stubbed fetch error). No custom error class — per "no abstractions for single-use."
+- **Token is never logged.** CLI prints summaries only; on error, stack trace may include URL but never the `Authorization` header.
+- **Rolling 371-day window**, computed in UTC, ending on today's UTC date. Matches the synthetic fixtures PR 002 uses (`TOTAL_DAYS = 371`) and GitHub's 53-week calendar grid. The GraphQL query passes `from` and `to` as ISO-8601 strings.
+- **Prototype (`prototypes/variant-d-grid-peaks.html`) is byte-identical.** No renderer edits either; `src/renderer.ts`, `src/normalize.ts`, `src/themes.ts`, `src/prng.ts` untouched.
+- `pnpm run ci` stays green: `check:repo`, `check:html`, `check:js`, `check:ts`, `build`, `format:check`, `test`. No new `ci` step needed — new tests slot into the existing `node --test "tests/**/*.test.mjs"` glob.
+
+## Validation
+
+- **Unit tests**: `pnpm test` runs the new `tests/data.test.mjs` alongside existing suites; all green.
+- **Offline determinism**: parser test calls `parseContributionsResponse(sample)` twice and asserts array equality.
+- **Transport correctness**: fetch-mock test inspects the exact request the module sends (URL, headers, body keys) without hitting the network.
+- **Manual live smoke**: `GITHUB_TOKEN=<pat> node scripts/fetch-contributions.mjs kiaquila` writes `sample-out/contributions-kiaquila.json` with 371 entries. Summary line prints active-day count and max count. (Reviewer repeats locally.)
+- **Type check**: `pnpm run check:ts` passes.
+- **Format**: `pnpm run format:check` passes — `scripts/**/*.mjs` and `specs/**/*.md` are already covered.
+- **No renderer regression**: `git diff origin/main -- src/renderer.ts src/normalize.ts src/themes.ts src/prng.ts` is empty.
+- **CI gates**: `baseline-checks`, `guard`, `AI Review` green on head SHA; Vercel preview no-op (prototype unchanged).
+
+## Acceptance
+
+- `pnpm test` runs ≥ 6 new test cases covering parser, transport, and error paths; all pass.
+- `parseContributionsResponse` exported and importable from `dist-renderer/data.js` after `pnpm run build:renderer`.
+- `scripts/fetch-contributions.mjs` fails cleanly when `GITHUB_TOKEN` is missing and when `username` is missing (exit code 1, single-line error).
+- `tests/fixtures/graphql-sample.json` committed; the file contains only `weeks[].contributionDays[]` data (no login, no avatarUrl, no email).
+- PR diff touches only: `specs/003-data-layer/**`, `src/data.ts`, `src/types.ts`, `tests/data.test.mjs`, `tests/fixtures/graphql-sample.json`, `scripts/fetch-contributions.mjs`, `package.json`.
+
+## Fixed design decisions (user-approved 2026-04-21)
+
+| Parameter             | Value                                                                                                                                           | Source        |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| Window length         | rolling 371 days from today (UTC), matching PR 002 synthetic fixtures                                                                           | user approval |
+| Endpoint              | `https://api.github.com/graphql` (hardcoded; GHE deferred post-MVP)                                                                             | user approval |
+| Token source          | env var `GITHUB_TOKEN` only (no CLI arg — avoids shell history leak)                                                                            | user approval |
+| Error shape           | plain `Error` with descriptive message + `cause` option (no custom class)                                                                       | user approval |
+| HTTP client           | Node 20 native `fetch` (no Octokit, no `undici`, no `node-fetch`)                                                                               | user approval |
+| GraphQL query         | minimal: `user(login) { contributionsCollection(from, to) { contributionCalendar { weeks { contributionDays { date contributionCount } } } } }` | user approval |
+| Sample fixture source | one real dump from user `kiaquila`, sanitized (only `weeks[]` retained)                                                                         | user approval |
+
+## Non-goals
+
+- Any form of authenticated request flow other than Bearer-token PAT. GitHub App installation tokens are a PR 004 concern (the Action's `${{ secrets.GITHUB_TOKEN }}` is also a PAT-shaped string; no code change needed there).
+- Caching, pagination, partial-year slicing — GitHub's `contributionsCollection` already returns a flat 53-week structure in a single request.
+- Richer return types (private vs public counts, repositories, etc.) — renderer only uses `{date, count}`.

--- a/specs/003-data-layer/tasks.md
+++ b/specs/003-data-layer/tasks.md
@@ -1,0 +1,78 @@
+# Tasks — Data layer
+
+## Fixture capture
+
+- [x] Create a throwaway PAT with `read:user` + `public_repo` scopes
+- [x] Run live GraphQL query against `api.github.com/graphql` for user `kiaquila`, rolling 371-day window
+- [x] Keep full GraphQL response wrapper (`{data: {user: {contributionsCollection: {contributionCalendar: {weeks: [...]}}}}}`); query requests no PII fields, so no stripping needed
+- [x] Save sanitized payload to `tests/fixtures/graphql-sample.json`
+- [x] Verify flattened day count (got: 53 weeks × 7 = 367 days; active=24, max=20) — GitHub aligns to week boundaries, parser must not hard-code 371
+
+## Types
+
+- [ ] Extend `src/types.ts` with `GraphQLContributionDay`, `GraphQLContributionWeek`, `GraphQLContributionsResponse`, `FetchOptions`
+- [ ] No breaking changes to existing `ContributionDay` / renderer types
+
+## `src/data.ts`
+
+- [ ] Export `parseContributionsResponse(payload: unknown): ContributionDay[]` with manual narrow type guards, flatten weeks, validate integer counts ≥ 0
+- [ ] Export `fetchContributions(username, token, opts?): Promise<ContributionDay[]>` — POST to `https://api.github.com/graphql` with Bearer token, minimal GraphQL query using variables (no interpolation)
+- [ ] Private `computeWindow(now = new Date()): { from: string; to: string }` — rolling 371-day UTC window
+- [ ] Private `buildQuery(username, from, to): { query, variables }`
+- [ ] Error mapping:
+  - [ ] Non-2xx → `Error('GitHub API request failed: HTTP <status>', { cause })`
+  - [ ] 403 with `x-ratelimit-remaining=0` → message mentions rate limit
+  - [ ] 200 + `payload.errors?.length` → `Error('GitHub GraphQL returned errors: <joined>', { cause: errors })`
+  - [ ] 200 + `payload.data.user === null` → `Error('GitHub user not found: <username>')`
+- [ ] `Authorization` header never logged; summaries print username + stats only
+
+## CLI `scripts/fetch-contributions.mjs`
+
+- [ ] Reads `username` from `argv[2]`, fails fast with usage hint if missing
+- [ ] Reads `GITHUB_TOKEN` from env, fails fast if missing
+- [ ] Prebuilds renderer via `spawnSync("pnpm", ["run", "build:renderer"])`, propagates exit code
+- [ ] Imports `../dist-renderer/data.js`, calls `fetchContributions`
+- [ ] Writes `sample-out/contributions-<username>.json` (pretty-printed, trailing newline)
+- [ ] Prints single summary line: `wrote <path> (active=N max=M first=YYYY-MM-DD last=YYYY-MM-DD)`
+- [ ] Add `fetch:sample` script alias in `package.json`
+
+## Tests `tests/data.test.mjs`
+
+- [ ] Parser: golden fixture → length matches fixture, chronological, all counts integers ≥ 0
+- [ ] Parser: empty-year payload (zeroed counts derived from fixture) → same length, all zeros
+- [ ] Parser: single-day-with-activity → exactly one count > 0
+- [ ] Parser: rejects malformed payload (missing `data.user`)
+- [ ] Parser: rejects non-integer `contributionCount`
+- [ ] Parser determinism: two calls on same sample → deepEqual arrays
+- [ ] Fetch transport: stub `globalThis.fetch`, assert URL, `Authorization: bearer <token>`, `Content-Type: application/json`, body includes `contributionsCollection` and username variable
+- [ ] Fetch error: HTTP 401 → thrown error message contains "HTTP 401"
+- [ ] Fetch error: HTTP 403 + `x-ratelimit-remaining: 0` → message contains "rate limit"
+- [ ] Fetch error: 200 body with `errors: [...]` → message joins GraphQL error messages
+- [ ] Fetch error: 200 body with `data.user: null` → message contains "user not found"
+- [ ] `afterEach` restores original `globalThis.fetch`
+
+## Verification
+
+- [ ] `pnpm run check:ts` green
+- [ ] `pnpm test` green (≥ 6 new cases passing)
+- [ ] `pnpm run ci` green end-to-end locally
+- [ ] `pnpm run check:feature-memory` green
+- [ ] Manual smoke: `GITHUB_TOKEN=<pat> node scripts/fetch-contributions.mjs kiaquila` writes valid `sample-out/contributions-kiaquila.json`
+- [ ] `git diff origin/main -- src/renderer.ts src/normalize.ts src/themes.ts src/prng.ts prototypes/` empty
+- [ ] `code-reviewer` subagent pass on `src/data.ts`, tests, CLI — focus: purity, narrow guards, error boundary, no token leak
+- [ ] Single commit on branch: `feat(data): GraphQL contributions fetcher + parser` (spec + code together)
+- [ ] Pre-push hook passes
+- [ ] PR opened against `main`
+- [ ] `@codex review` posted via `gh` after initial push and after every subsequent push
+- [ ] `baseline-checks`, `guard`, `AI Review` green on PR head SHA
+- [ ] Vercel preview green (prototype unchanged)
+- [ ] All blocking Codex findings resolved
+
+## Out of scope (deferred)
+
+- [ ] `action.yml` + ncc bundle + output-branch push — PR 004 (`specs/004-action-entrypoint/`)
+- [ ] Dogfood workflow + README embed — PR 005 (`specs/005-dogfood/`)
+- [ ] `--from` / `--to` CLI flags
+- [ ] GitHub Enterprise host support
+- [ ] Retries / timeouts / backoff
+- [ ] Octokit or any HTTP/GraphQL client dep

--- a/src/data.ts
+++ b/src/data.ts
@@ -144,9 +144,11 @@ export function parseContributionsResponse(
 }
 
 function computeWindow(now: Date): { from: string; to: string } {
+  // GitHub's contributionsCollection treats [from, to] as inclusive bounds,
+  // so a WINDOW_DAYS-day window spans from (now - (WINDOW_DAYS - 1)) to now.
   const to = new Date(now.getTime());
   const from = new Date(now.getTime());
-  from.setUTCDate(from.getUTCDate() - WINDOW_DAYS);
+  from.setUTCDate(from.getUTCDate() - (WINDOW_DAYS - 1));
   return { from: from.toISOString(), to: to.toISOString() };
 }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,0 +1,163 @@
+import type { ContributionDay, FetchOptions } from "./types.js";
+
+const ENDPOINT = "https://api.github.com/graphql";
+const USER_AGENT = "comet-contribution-graph/0.1";
+const WINDOW_DAYS = 371;
+
+const QUERY = `query($login: String!, $from: DateTime!, $to: DateTime!) {
+  user(login: $login) {
+    contributionsCollection(from: $from, to: $to) {
+      contributionCalendar {
+        weeks {
+          contributionDays { date contributionCount }
+        }
+      }
+    }
+  }
+}`;
+
+export async function fetchContributions(
+  username: string,
+  token: string,
+  opts: FetchOptions = {},
+): Promise<ContributionDay[]> {
+  const now = opts.now ?? new Date();
+  const { from, to } = computeWindow(now);
+  const response = await fetch(ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `bearer ${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "User-Agent": USER_AGENT,
+    },
+    body: JSON.stringify({
+      query: QUERY,
+      variables: { login: username, from, to },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = (await safeText(response)).slice(0, 500);
+    const rateRemaining = response.headers.get("x-ratelimit-remaining");
+    const rateSuffix =
+      response.status === 403 && rateRemaining === "0"
+        ? " (rate limit exhausted)"
+        : "";
+    throw new Error(
+      `GitHub API request failed: HTTP ${response.status}${rateSuffix}`,
+      { cause: { status: response.status, bodyExcerpt: body } },
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    throw new Error("GitHub API returned malformed JSON", { cause });
+  }
+
+  if (isObj(payload)) {
+    const errs = payload["errors"];
+    if (Array.isArray(errs) && errs.length > 0) {
+      const joined = errs
+        .map((e) =>
+          isObj(e) && typeof e["message"] === "string"
+            ? e["message"]
+            : "(no message)",
+        )
+        .join("; ");
+      throw new Error(`GitHub GraphQL returned errors: ${joined}`, {
+        cause: errs,
+      });
+    }
+    const data = payload["data"];
+    if (isObj(data) && data["user"] === null) {
+      throw new Error(`GitHub user not found: ${username}`);
+    }
+  }
+
+  return parseContributionsResponse(payload);
+}
+
+export function parseContributionsResponse(
+  payload: unknown,
+): ContributionDay[] {
+  if (!isObj(payload)) {
+    throw new Error("invalid payload: expected top-level object");
+  }
+  const data = payload["data"];
+  if (!isObj(data)) {
+    throw new Error("invalid payload: missing data");
+  }
+  const user = data["user"];
+  if (user === null) {
+    throw new Error("GitHub user not found (data.user is null)");
+  }
+  if (!isObj(user)) {
+    throw new Error("invalid payload: missing data.user");
+  }
+  const collection = user["contributionsCollection"];
+  if (!isObj(collection)) {
+    throw new Error("invalid payload: missing contributionsCollection");
+  }
+  const calendar = collection["contributionCalendar"];
+  if (!isObj(calendar)) {
+    throw new Error("invalid payload: missing contributionCalendar");
+  }
+  const weeks = calendar["weeks"];
+  if (!Array.isArray(weeks)) {
+    throw new Error("invalid payload: weeks is not an array");
+  }
+
+  const out: ContributionDay[] = [];
+  for (const week of weeks) {
+    if (!isObj(week)) {
+      throw new Error("invalid payload: week is not an object");
+    }
+    const days = week["contributionDays"];
+    if (!Array.isArray(days)) {
+      throw new Error("invalid payload: contributionDays is not an array");
+    }
+    for (const day of days) {
+      if (!isObj(day)) {
+        throw new Error("invalid payload: day is not an object");
+      }
+      const date = day["date"];
+      const count = day["contributionCount"];
+      if (typeof date !== "string") {
+        throw new Error("invalid payload: day.date is not a string");
+      }
+      if (
+        typeof count !== "number" ||
+        !Number.isInteger(count) ||
+        count < 0
+      ) {
+        throw new Error(
+          `invalid payload: contributionCount is not an integer ≥ 0 (got ${String(count)})`,
+        );
+      }
+      out.push({ date, count });
+    }
+  }
+  return out;
+}
+
+function computeWindow(now: Date): { from: string; to: string } {
+  const to = new Date(now.getTime());
+  const from = new Date(now.getTime());
+  from.setUTCDate(from.getUTCDate() - WINDOW_DAYS);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+async function safeText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "";
+  }
+}
+
+function isObj(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,3 +43,7 @@ export interface Normalization {
   readonly median: number;
   readonly peakFloor: number;
 }
+
+export interface FetchOptions {
+  readonly now?: Date;
+}

--- a/tests/data.test.mjs
+++ b/tests/data.test.mjs
@@ -1,0 +1,226 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test, { afterEach, beforeEach } from "node:test";
+import {
+  deepStrictEqual,
+  match,
+  rejects,
+  strictEqual,
+  throws,
+} from "node:assert/strict";
+
+import {
+  fetchContributions,
+  parseContributionsResponse,
+} from "../dist-renderer/data.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = resolve(here, "fixtures/graphql-sample.json");
+const goldenPayload = () => JSON.parse(readFileSync(FIXTURE_PATH, "utf8"));
+const fixtureDays = () =>
+  goldenPayload().data.user.contributionsCollection.contributionCalendar.weeks.flatMap(
+    (w) => w.contributionDays,
+  );
+
+function wrap(weeks) {
+  return {
+    data: {
+      user: { contributionsCollection: { contributionCalendar: { weeks } } },
+    },
+  };
+}
+
+function zeroedPayload() {
+  const p = goldenPayload();
+  for (const week of p.data.user.contributionsCollection.contributionCalendar
+    .weeks) {
+    for (const day of week.contributionDays) {
+      day.contributionCount = 0;
+    }
+  }
+  return p;
+}
+
+function singleActivityPayload() {
+  const p = zeroedPayload();
+  const firstWeek =
+    p.data.user.contributionsCollection.contributionCalendar.weeks[0];
+  firstWeek.contributionDays[0].contributionCount = 7;
+  return p;
+}
+
+const originalFetch = globalThis.fetch;
+let fetchCalls = [];
+let fetchImpl = null;
+
+beforeEach(() => {
+  fetchCalls = [];
+  fetchImpl = null;
+  globalThis.fetch = async (url, init) => {
+    fetchCalls.push({ url, init });
+    if (!fetchImpl) {
+      throw new Error("fetch stub not configured for this test");
+    }
+    return fetchImpl(url, init);
+  };
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function jsonResponse(body, { status = 200, headers = {} } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(headers),
+    async json() {
+      return body;
+    },
+    async text() {
+      return JSON.stringify(body);
+    },
+  };
+}
+
+test("parser: golden fixture → length matches, chronological, counts integer ≥ 0", () => {
+  const days = parseContributionsResponse(goldenPayload());
+  const expected = fixtureDays();
+  strictEqual(days.length, expected.length);
+  strictEqual(days.length > 0, true);
+  for (let i = 0; i < days.length; i += 1) {
+    strictEqual(days[i].date, expected[i].date);
+    strictEqual(days[i].count, expected[i].contributionCount);
+    strictEqual(Number.isInteger(days[i].count), true);
+    strictEqual(days[i].count >= 0, true);
+    if (i > 0) {
+      strictEqual(days[i - 1].date < days[i].date, true);
+    }
+  }
+});
+
+test("parser: zeroed payload → same length, all zeros", () => {
+  const days = parseContributionsResponse(zeroedPayload());
+  strictEqual(days.length, fixtureDays().length);
+  strictEqual(
+    days.every((d) => d.count === 0),
+    true,
+  );
+});
+
+test("parser: single-day-with-activity → exactly one count > 0", () => {
+  const days = parseContributionsResponse(singleActivityPayload());
+  strictEqual(days.filter((d) => d.count > 0).length, 1);
+  strictEqual(days.find((d) => d.count > 0).count, 7);
+});
+
+test("parser: rejects payload with data.user = null", () => {
+  throws(
+    () => parseContributionsResponse({ data: { user: null } }),
+    /user not found/,
+  );
+});
+
+test("parser: empty weeks array → empty result", () => {
+  const days = parseContributionsResponse(wrap([]));
+  deepStrictEqual(days, []);
+});
+
+test("parser: rejects missing data object", () => {
+  throws(() => parseContributionsResponse({}), /missing data/);
+});
+
+test("parser: rejects non-integer contributionCount", () => {
+  const bad = wrap([
+    { contributionDays: [{ date: "2026-01-01", contributionCount: 1.5 }] },
+  ]);
+  throws(() => parseContributionsResponse(bad), /integer/);
+});
+
+test("parser: rejects negative contributionCount", () => {
+  const bad = wrap([
+    { contributionDays: [{ date: "2026-01-01", contributionCount: -1 }] },
+  ]);
+  throws(() => parseContributionsResponse(bad), /integer/);
+});
+
+test("parser: determinism — two calls return deepEqual arrays", () => {
+  const a = parseContributionsResponse(goldenPayload());
+  const b = parseContributionsResponse(goldenPayload());
+  deepStrictEqual(a, b);
+});
+
+test("fetch: POST sends correct URL, headers, and body shape", async () => {
+  fetchImpl = async () => jsonResponse(goldenPayload());
+  await fetchContributions("kiaquila", "secret-token-abc");
+  strictEqual(fetchCalls.length, 1);
+  const call = fetchCalls[0];
+  strictEqual(call.url, "https://api.github.com/graphql");
+  strictEqual(call.init.method, "POST");
+  strictEqual(call.init.headers.Authorization, "bearer secret-token-abc");
+  strictEqual(call.init.headers["Content-Type"], "application/json");
+  const body = JSON.parse(call.init.body);
+  match(body.query, /contributionsCollection/);
+  strictEqual(body.variables.login, "kiaquila");
+  strictEqual(typeof body.variables.from, "string");
+  strictEqual(typeof body.variables.to, "string");
+});
+
+test("fetch: rolling 371-day window respects injected now", async () => {
+  fetchImpl = async () => jsonResponse(goldenPayload());
+  const now = new Date("2026-04-21T12:00:00Z");
+  await fetchContributions("kiaquila", "t", { now });
+  const body = JSON.parse(fetchCalls[0].init.body);
+  strictEqual(body.variables.to, "2026-04-21T12:00:00.000Z");
+  strictEqual(body.variables.from, "2025-04-15T12:00:00.000Z");
+});
+
+test("fetch: HTTP 401 throws with status in message", async () => {
+  fetchImpl = async () =>
+    jsonResponse({ message: "Bad credentials" }, { status: 401 });
+  await rejects(fetchContributions("kiaquila", "bad-token"), /HTTP 401/);
+});
+
+test("fetch: HTTP 403 with x-ratelimit-remaining=0 mentions rate limit", async () => {
+  fetchImpl = async () =>
+    jsonResponse(
+      { message: "API rate limit exceeded" },
+      { status: 403, headers: { "x-ratelimit-remaining": "0" } },
+    );
+  await rejects(fetchContributions("kiaquila", "t"), /rate limit/);
+});
+
+test("fetch: 200 body with errors[] throws with joined message", async () => {
+  fetchImpl = async () =>
+    jsonResponse({
+      errors: [{ message: "first problem" }, { message: "second problem" }],
+    });
+  await rejects(
+    fetchContributions("kiaquila", "t"),
+    /first problem; second problem/,
+  );
+});
+
+test("fetch: 200 body with data.user=null throws user-not-found", async () => {
+  fetchImpl = async () => jsonResponse({ data: { user: null } });
+  await rejects(
+    fetchContributions("ghost-user-404", "t"),
+    /user not found: ghost-user-404/,
+  );
+});
+
+test("fetch: malformed JSON body throws wrapper error", async () => {
+  fetchImpl = async () => ({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    async json() {
+      throw new SyntaxError("Unexpected token");
+    },
+    async text() {
+      return "not json";
+    },
+  });
+  await rejects(fetchContributions("kiaquila", "t"), /malformed JSON/);
+});

--- a/tests/data.test.mjs
+++ b/tests/data.test.mjs
@@ -173,7 +173,8 @@ test("fetch: rolling 371-day window respects injected now", async () => {
   await fetchContributions("kiaquila", "t", { now });
   const body = JSON.parse(fetchCalls[0].init.body);
   strictEqual(body.variables.to, "2026-04-21T12:00:00.000Z");
-  strictEqual(body.variables.from, "2025-04-15T12:00:00.000Z");
+  // Inclusive 371-day window: from = now - 370 days.
+  strictEqual(body.variables.from, "2025-04-16T12:00:00.000Z");
 });
 
 test("fetch: HTTP 401 throws with status in message", async () => {

--- a/tests/fixtures/graphql-sample.json
+++ b/tests/fixtures/graphql-sample.json
@@ -1,0 +1,1692 @@
+{
+  "data": {
+    "user": {
+      "contributionsCollection": {
+        "contributionCalendar": {
+          "weeks": [
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-04-20",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-04-21",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-04-22",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-04-23",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-04-24",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-04-25",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-04-26",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-04-27",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-04-28",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-04-29",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-04-30",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-01",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-02",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-03",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-05-04",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-05",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-06",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-07",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-08",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-09",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-10",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-05-11",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-12",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-13",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-14",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-15",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-16",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-17",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-05-18",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-19",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-20",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-21",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-22",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-23",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-24",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-05-25",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-26",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-27",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-28",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-29",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-30",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-05-31",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-06-01",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-02",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-03",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-04",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-05",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-06",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-07",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-06-08",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-09",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-10",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-11",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-12",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-13",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-14",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-06-15",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-16",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-17",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-18",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-19",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-20",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-21",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-06-22",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-23",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-24",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-25",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-26",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-27",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-28",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-06-29",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-06-30",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-01",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-02",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-03",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-04",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-05",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-07-06",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-07",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-08",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-09",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-10",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-11",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-12",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-07-13",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-14",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-15",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-16",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-17",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-18",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-19",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-07-20",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-21",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-22",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-23",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-24",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-25",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-26",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-07-27",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-28",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-29",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-30",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-07-31",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-01",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-02",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-08-03",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-04",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-05",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-06",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-07",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-08",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-09",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-08-10",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-11",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-12",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-13",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-14",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-15",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-16",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-08-17",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-18",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-19",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-20",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-21",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-22",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-23",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-08-24",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-25",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-26",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-27",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-28",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-29",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-08-30",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-08-31",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-01",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-02",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-03",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-04",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-05",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-06",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-09-07",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-08",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-09",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-10",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-11",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-12",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-13",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-09-14",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-15",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-16",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-17",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-18",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-19",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-20",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-09-21",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-22",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-23",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-24",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-25",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-26",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-27",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-09-28",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-29",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-09-30",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-01",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-02",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-03",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-04",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-10-05",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-06",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-07",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-08",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-09",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-10",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-11",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-10-12",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-13",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-14",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-15",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-16",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-17",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-18",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-10-19",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-20",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-21",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-22",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-23",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-24",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-25",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-10-26",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-27",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-28",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-29",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-30",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-10-31",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-01",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-11-02",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-03",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-04",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-05",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-06",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-07",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-08",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-11-09",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-10",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-11",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-12",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-13",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-14",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-15",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-11-16",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-17",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-18",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-19",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-20",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-21",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-22",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-11-23",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-24",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-25",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-26",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-27",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-28",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-11-29",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-11-30",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-01",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-02",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-03",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-04",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-05",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-06",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-12-07",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-08",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-09",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-10",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-11",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-12",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-13",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-12-14",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-15",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-16",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-17",
+                  "contributionCount": 2
+                },
+                {
+                  "date": "2025-12-18",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-19",
+                  "contributionCount": 2
+                },
+                {
+                  "date": "2025-12-20",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-12-21",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-22",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-23",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-24",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-25",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-26",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-27",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2025-12-28",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-29",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-30",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2025-12-31",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-01",
+                  "contributionCount": 1
+                },
+                {
+                  "date": "2026-01-02",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-03",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-01-04",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-05",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-06",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-07",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-08",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-09",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-10",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-01-11",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-12",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-13",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-14",
+                  "contributionCount": 1
+                },
+                {
+                  "date": "2026-01-15",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-16",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-17",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-01-18",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-19",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-20",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-21",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-22",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-23",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-24",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-01-25",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-26",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-27",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-28",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-29",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-30",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-01-31",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-02-01",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-02",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-03",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-04",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-05",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-06",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-07",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-02-08",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-09",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-10",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-11",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-12",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-13",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-14",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-02-15",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-16",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-17",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-18",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-19",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-20",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-21",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-02-22",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-23",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-24",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-25",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-26",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-27",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-02-28",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-03-01",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-02",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-03",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-04",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-05",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-06",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-07",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-03-08",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-09",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-10",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-11",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-12",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-13",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-14",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-03-15",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-16",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-17",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-18",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-19",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-20",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-21",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-03-22",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-23",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-24",
+                  "contributionCount": 1
+                },
+                {
+                  "date": "2026-03-25",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-26",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-27",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-28",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-03-29",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-30",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-03-31",
+                  "contributionCount": 1
+                },
+                {
+                  "date": "2026-04-01",
+                  "contributionCount": 1
+                },
+                {
+                  "date": "2026-04-02",
+                  "contributionCount": 4
+                },
+                {
+                  "date": "2026-04-03",
+                  "contributionCount": 11
+                },
+                {
+                  "date": "2026-04-04",
+                  "contributionCount": 0
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-04-05",
+                  "contributionCount": 0
+                },
+                {
+                  "date": "2026-04-06",
+                  "contributionCount": 5
+                },
+                {
+                  "date": "2026-04-07",
+                  "contributionCount": 6
+                },
+                {
+                  "date": "2026-04-08",
+                  "contributionCount": 5
+                },
+                {
+                  "date": "2026-04-09",
+                  "contributionCount": 19
+                },
+                {
+                  "date": "2026-04-10",
+                  "contributionCount": 20
+                },
+                {
+                  "date": "2026-04-11",
+                  "contributionCount": 6
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-04-12",
+                  "contributionCount": 3
+                },
+                {
+                  "date": "2026-04-13",
+                  "contributionCount": 3
+                },
+                {
+                  "date": "2026-04-14",
+                  "contributionCount": 5
+                },
+                {
+                  "date": "2026-04-15",
+                  "contributionCount": 10
+                },
+                {
+                  "date": "2026-04-16",
+                  "contributionCount": 16
+                },
+                {
+                  "date": "2026-04-17",
+                  "contributionCount": 8
+                },
+                {
+                  "date": "2026-04-18",
+                  "contributionCount": 19
+                }
+              ]
+            },
+            {
+              "contributionDays": [
+                {
+                  "date": "2026-04-19",
+                  "contributionCount": 2
+                },
+                {
+                  "date": "2026-04-20",
+                  "contributionCount": 6
+                },
+                {
+                  "date": "2026-04-21",
+                  "contributionCount": 0
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/data.ts`: pure TS module with `fetchContributions(username, token, opts?)` (native Node 20 `fetch`, POST to `api.github.com/graphql`, rolling 371-day window) and `parseContributionsResponse(payload)` (pure parser with narrow-guarded `unknown`).
- Adds `scripts/fetch-contributions.mjs`: CLI wrapper for manual real-data smoke (`GITHUB_TOKEN` env + username arg).
- Adds `tests/data.test.mjs` (16 cases: parser + fetch transport + error paths) and `tests/fixtures/graphql-sample.json` (real dump from user `kiaquila`, 53 weeks × 7 = 367 days).
- Feature memory: `specs/003-data-layer/{spec,plan,tasks}.md` with fixed decisions (rolling 371, hardcoded api.github.com, `GITHUB_TOKEN` env only, no custom error class).

## Why this shape

- **No runtime dependencies**, no Octokit, no schema library — native `fetch` + manual narrow guards in ~160 LOC of TS.
- **Error boundary only at system edges**: plain `Error` + `cause` with a truncated (500 char) `bodyExcerpt` to avoid leaking future proxy headers.
- **Parser is pure and deterministic** — verified by test. No clock, no PRNG, no mutable state.
- **Token hygiene**: `Authorization` never appears in any error message, log, or cause chain (verified by local code-reviewer pass).
- **No abstractions for single-use** (CLAUDE.md rule): no GraphQL response types exported — the parser operates on `unknown`, so static types were dead documentation.

## Scope boundaries

Out of scope (per roadmap):
- Wiring `fetchContributions → renderCometSVG` end-to-end — PR 004.
- `action.yml` + ncc bundle + orphan output-branch push — PR 004.
- GitHub Enterprise host support, retries/timeouts, `--from`/`--to` CLI flags — deferred.

## Test plan

- [x] `pnpm run ci` green locally (check:repo, check:html, check:js, check:ts, build, format:check, test → 44/44)
- [x] Local `code-reviewer` subagent pass — 0 P0; all P1/P2 addressed
- [ ] `baseline-checks` green on PR head SHA
- [ ] `guard` green
- [ ] `AI Review` (Codex) green, all blocking findings resolved
- [ ] Vercel preview green (prototype unchanged → expected no-op)
- [ ] Manual live smoke: `GITHUB_TOKEN=<pat> node scripts/fetch-contributions.mjs kiaquila` writes valid `sample-out/contributions-kiaquila.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)