### PR TITLE
feat(dogfood): comet-graph workflow + README publish (PR 005)

### DIFF
--- a/.github/workflows/comet-graph.yml
+++ b/.github/workflows/comet-graph.yml
@@ -1,0 +1,19 @@
+name: comet-graph
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+concurrency:
+  group: comet-graph
+  cancel-in-progress: true
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          username: kiaquila

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ For users who prefer reduced motion, serve the static companion SVG via a `<pict
 
 ### Inputs
 
-| name       | required | default               | description                                                                                         |
-| ---------- | -------- | --------------------- | --------------------------------------------------------------------------------------------------- |
-| `username` | yes      | —                     | GitHub login to render the graph for                                                                |
-| `token`    | no       | `${{ github.token }}` | PAT with `read:user` + repo write access for cross-repo setups; default works for owner's own graph |
-| `reduced`  | no       | `"true"`              | Also emit `comet-reduced.svg` for `prefers-reduced-motion` fallback                                 |
-| `branch`   | no       | `"comet-graph"`       | Output branch; force-pushed on every run                                                            |
+| name       | required | default               | description                                                                                                                                              |
+| ---------- | -------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `username` | yes      | —                     | GitHub login to render the graph for                                                                                                                     |
+| `token`    | no       | `${{ github.token }}` | Token with `contents:write` on the target repo; for cross-repo use a classic PAT with `repo` scope or a fine-grained PAT with `Contents: Read and write` |
+| `reduced`  | no       | `"true"`              | Also emit `comet-reduced.svg` for `prefers-reduced-motion` fallback                                                                                      |
+| `branch`   | no       | `"comet-graph"`       | Output branch; force-pushed on every run                                                                                                                 |
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -58,16 +58,16 @@ For users who prefer reduced motion, serve the static companion SVG via a `<pict
 
 ### Inputs
 
-| name       | required | default               | description                                                                             |
-| ---------- | -------- | --------------------- | --------------------------------------------------------------------------------------- |
-| `username` | yes      | —                     | GitHub login to render the graph for                                                    |
-| `token`    | no       | `${{ github.token }}` | PAT with `read:user` only if querying another user; default works for owner's own graph |
-| `reduced`  | no       | `"true"`              | Also emit `comet-reduced.svg` for `prefers-reduced-motion` fallback                     |
-| `branch`   | no       | `"comet-graph"`       | Output branch; force-pushed on every run                                                |
+| name       | required | default               | description                                                                                         |
+| ---------- | -------- | --------------------- | --------------------------------------------------------------------------------------------------- |
+| `username` | yes      | —                     | GitHub login to render the graph for                                                                |
+| `token`    | no       | `${{ github.token }}` | PAT with `read:user` + repo write access for cross-repo setups; default works for owner's own graph |
+| `reduced`  | no       | `"true"`              | Also emit `comet-reduced.svg` for `prefers-reduced-motion` fallback                                 |
+| `branch`   | no       | `"comet-graph"`       | Output branch; force-pushed on every run                                                            |
 
 ## How it works
 
-Every run fetches your GitHub contributions via the GraphQL API, passes them through a pure-TS SVG renderer (SMIL-animated comet tracing your most productive days across a constellation of your year), and force-pushes the result to an orphan `comet-graph` branch in this repo. Your profile README embeds the SVG via a stable `raw.githubusercontent.com` URL. See [github-action-target.md](./docs_comet/project/devops/github-action-target.md) for the architecture contract.
+Every run fetches your GitHub contributions via the GraphQL API, passes them through a pure-TS SVG renderer (SMIL-animated comet tracing your most productive days across a constellation of your year), and force-pushes the result to an orphan `comet-graph` branch in the repository where the workflow runs. Your profile README embeds the SVG via a stable `raw.githubusercontent.com` URL. See [github-action-target.md](./docs_comet/project/devops/github-action-target.md) for the architecture contract.
 
 ## Concept
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,72 @@
 
 A cinematic GitHub contribution graph. A comet traces your most productive days across a constellation of your year.
 
-**Status:** Work in progress — private preview. An initial public release with a GitHub Action and install instructions will follow once the first version is ready.
+[![comet-graph](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/comet-graph.yml/badge.svg)](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/comet-graph.yml) [![OSV Scanner](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/osv-scan.yml/badge.svg)](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/osv-scan.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
+![cinematic comet contribution graph](https://raw.githubusercontent.com/kiaquila/comet-contribution-graph/comet-graph/comet.svg)
+
+## Usage
+
+Add the following workflow to your profile repo (`<user>/<user>`) to render and publish your comet graph on a weekly schedule. The Action fetches your contribution data, renders the SVG, and force-pushes it to a `comet-graph` branch in the same repo.
+
+```yaml
+# .github/workflows/comet-graph.yml in <user>/<user>
+name: comet-graph
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: kiaquila/comet-contribution-graph@main
+        with:
+          username: <user>
+```
+
+`v1` tag coming post-MVP; pin to `@main` or a commit SHA for reproducibility.
+
+### Embed in your profile README
+
+```markdown
+![cinematic comet contribution graph](https://raw.githubusercontent.com/<user>/<user>/comet-graph/comet.svg)
+```
+
+### Reduced-motion fallback
+
+For users who prefer reduced motion, serve the static companion SVG via a `<picture>` element:
+
+```html
+<picture>
+  <source
+    media="(prefers-reduced-motion: reduce)"
+    srcset="
+      https://raw.githubusercontent.com/<user>/<user>/comet-graph/comet-reduced.svg
+    "
+  />
+  <img
+    alt="cinematic comet contribution graph"
+    src="https://raw.githubusercontent.com/<user>/<user>/comet-graph/comet.svg"
+  />
+</picture>
+```
+
+### Inputs
+
+| name       | required | default               | description                                                                             |
+| ---------- | -------- | --------------------- | --------------------------------------------------------------------------------------- |
+| `username` | yes      | —                     | GitHub login to render the graph for                                                    |
+| `token`    | no       | `${{ github.token }}` | PAT with `read:user` only if querying another user; default works for owner's own graph |
+| `reduced`  | no       | `"true"`              | Also emit `comet-reduced.svg` for `prefers-reduced-motion` fallback                     |
+| `branch`   | no       | `"comet-graph"`       | Output branch; force-pushed on every run                                                |
+
+## How it works
+
+Every run fetches your GitHub contributions via the GraphQL API, passes them through a pure-TS SVG renderer (SMIL-animated comet tracing your most productive days across a constellation of your year), and force-pushes the result to an orphan `comet-graph` branch in this repo. Your profile README embeds the SVG via a stable `raw.githubusercontent.com` URL. See [github-action-target.md](./docs_comet/project/devops/github-action-target.md) for the architecture contract.
 
 ## Concept
 
@@ -11,19 +76,14 @@ A cinematic GitHub contribution graph. A comet traces your most productive days 
 - A comet flies through them chronologically, leaving a glowing trail.
 - Inactive cells fade into a deep night sky; a soft layer of background stars adds atmosphere.
 
-## Current state
-
-- `prototypes/variant-d-grid-peaks.html` — standalone HTML prototype with fake realistic data. Open in a browser to preview.
-- No product `index.html` yet — the prototype is the working artifact.
-- Final deliverable: a published GitHub Action that renders the graph as SVG, embeddable in any user's README. Vercel hosts a preview of the prototype during development.
-
 ## Stack
 
-- Static prototype (HTML + CSS + inline JS, single file)
-- Fonts: Space Mono via Google Fonts (CDN)
-- Build: `scripts/build-static.mjs` copies the active prototype to `dist/index.html` for preview
-- Hosting (preview): Vercel (Git integration, preview deploys per PR)
-- CI: GitHub Actions (`baseline-checks`, `guard`, `AI Review`)
+- Node 20 GitHub Action, bundled single-file via `@vercel/ncc` (committed at `dist-action/index.js`)
+- Pure-TypeScript SVG renderer (`src/renderer.ts`) with SMIL animation
+- GitHub GraphQL `contributionsCollection` data source (`src/data.ts`)
+- System `monospace` font (embed-safe, no CDN)
+- Prototype (`prototypes/variant-d-grid-peaks.html`) — development preview, deployed to Vercel per-PR
+- CI: GitHub Actions (`baseline-checks`, `guard`, `AI Review`, `OSV Scanner`, `comet-graph` dogfood)
 
 ## Getting started
 
@@ -46,6 +106,9 @@ Open `prototypes/variant-d-grid-peaks.html` directly in a browser, or serve `dis
 | `pnpm run check:repo`           | Repository baseline checks                             |
 | `pnpm run check:html`           | HTML validation against the active prototype           |
 | `pnpm run check:feature-memory` | Enforce `specs/<feature-id>/` for product changes      |
+| `pnpm run check:ts`             | TypeScript strict-mode compile check                   |
+| `pnpm run build:action`         | Produce `dist-action/index.js` via ncc                 |
+| `pnpm run check:dist`           | Verify committed bundle matches source                 |
 | `pnpm run format:check`         | Prettier check across tracked files                    |
 | `pnpm run test`                 | Run Node test runner against `tests/`                  |
 | `pnpm run ci`                   | Full local CI pipeline                                 |
@@ -63,14 +126,17 @@ Dependabot (`.github/dependabot.yml`) opens weekly PRs for npm and github-action
 
 ```
 comet-contribution-graph/
-├── prototypes/                  # Standalone HTML prototypes
+├── src/                         # Pure-TS Action: renderer, data, entry
+├── dist-action/                 # Committed ncc bundle (Node 20 single-file)
+├── prototypes/                  # Standalone HTML prototype
 │   └── variant-d-grid-peaks.html
 ├── scripts/                     # Build and orchestration helpers
-├── tests/                       # Node test suites
+├── tests/                       # Node test suites + fixtures + snapshots
 ├── specs/<feature-id>/          # Per-feature spec.md / plan.md / tasks.md
 ├── docs_comet/                  # Durable docs, ADRs, devops contracts
 ├── .specify/memory/             # Constitution and process rules
-├── .github/workflows/           # CI, guard, AI review, OSV scan
+├── .github/workflows/           # CI, guard, AI review, OSV scan, dogfood
+├── action.yml                   # GitHub Action metadata
 ├── vercel.json                  # Vercel build/output configuration
 └── AGENTS.md / CLAUDE.md        # Agent onboarding
 ```

--- a/docs_comet/project/devops/github-action-target.md
+++ b/docs_comet/project/devops/github-action-target.md
@@ -12,8 +12,8 @@ Publish a public GitHub Action that any developer installs in their profile repo
 - CI infra (ESLint, html-validate, feature-memory gate, Playwright smoke, Codex review) — green (PR #4 merged).
 - PR 002 — renderer extraction — merged. Pure-TS SVG renderer, SMIL animation, snapshot tests.
 - PR 003 — data layer — merged. GraphQL `contributionsCollection` fetcher + parser, 43 tests.
-- **PR 004 — Action entrypoint — in review.** `action.yml` + `src/action.ts` + `@vercel/ncc` bundle in `dist-action/` + orphan force-push. All local checks green.
-- PR 005 — not started; spec not yet written (see "Forward-referencing specs" below).
+- **PR 004 — Action entrypoint — MERGED (squash `7225f17`).** `action.yml` + `src/action.ts` + `@vercel/ncc` bundle in `dist-action/` + orphan force-push. All local checks green.
+- PR 005 — dogfood workflow + README publish — in review.
 
 ### Closed-in-PR-002 scope
 
@@ -35,18 +35,22 @@ Publish a public GitHub Action that any developer installs in their profile repo
 
 ## 4-PR roadmap to MVP
 
-| #   | Spec                                                                      | Size | What lands                                                                                                                                                                                           |
-| --- | ------------------------------------------------------------------------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 002 | [specs/002-renderer-extraction/](../../../specs/002-renderer-extraction/) | L    | Pure TS SVG renderer (`src/renderer.ts`, `normalize.ts`, `themes.ts`, `prng.ts`), TypeScript toolchain, SMIL animation migration, snapshot tests against fixture profiles. Prototype untouched.      |
-| 003 | `specs/003-data-layer/` (created when PR 002 merges)                      | M    | `src/data.ts` — GraphQL `contributionsCollection` fetcher + parser, fixture JSON files, CLI `scripts/fetch-contributions.mjs` for manual real-data verification.                                     |
-| 004 | [specs/004-action-entrypoint/](../../../specs/004-action-entrypoint/)     | L    | `action.yml` + `src/action.ts` + `@vercel/ncc` bundle in `dist-action/` + orphan force-push to `comet-graph` branch. CI "dist up-to-date" check. `.gitattributes linguist-generated`. **In review.** |
-| 005 | `specs/005-dogfood/` (created when PR 004 merges)                         | S    | `.github/workflows/comet-graph.yml` (weekly cron + `workflow_dispatch`), README overhaul with `<img>` embed (optional `<picture>` for reduced-motion fallback), usage docs for external users.       |
+| #   | Spec                                                                      | Size | What lands                                                                                                                                                                                                       |
+| --- | ------------------------------------------------------------------------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 002 | [specs/002-renderer-extraction/](../../../specs/002-renderer-extraction/) | L    | Pure TS SVG renderer (`src/renderer.ts`, `normalize.ts`, `themes.ts`, `prng.ts`), TypeScript toolchain, SMIL animation migration, snapshot tests against fixture profiles. Prototype untouched. ✅ MERGED        |
+| 003 | `specs/003-data-layer/` (created when PR 002 merges)                      | M    | `src/data.ts` — GraphQL `contributionsCollection` fetcher + parser, fixture JSON files, CLI `scripts/fetch-contributions.mjs` for manual real-data verification. ✅ MERGED                                       |
+| 004 | [specs/004-action-entrypoint/](../../../specs/004-action-entrypoint/)     | L    | `action.yml` + `src/action.ts` + `@vercel/ncc` bundle in `dist-action/` + orphan force-push to `comet-graph` branch. CI "dist up-to-date" check. `.gitattributes linguist-generated`. **✅ MERGED.**             |
+| 005 | `specs/005-dogfood/` (created when PR 004 merges)                         | S    | `.github/workflows/comet-graph.yml` (weekly cron + `workflow_dispatch`), README overhaul with `<img>` embed (optional `<picture>` for reduced-motion fallback), usage docs for external users. 🚧 **In review.** |
 
 **Why 4 PRs, not 3 or 5.** Three would combine TypeScript toolchain, rendering, GraphQL, and normalization in one PR — too broad for Codex review (historical data: 6 cycles on L-size PRs). Five would split normalization away from its only consumer (the renderer), violating the CLAUDE.md "no abstractions for single-use" rule.
 
 ### Forward-referencing specs
 
 Specs for PR 003/004/005 are intentionally NOT written yet. Their scope will be refined by what we learn shipping PR 002 (actual SMIL behavior through camo, snapshot testing ergonomics, TS build quirks). Writing them now would be premature — they would rot before execution. Create each spec when its PR begins.
+
+## Near-term follow-ups (post-PR-005)
+
+- **PR 006 — profile-repo dogfood (Option B of Option C strategy).** Install the Action in `kiaquila/kiaquila` profile repo via `uses: kiaquila/comet-contribution-graph@main`; push SVG to the profile repo's own `comet-graph` branch using that repo's default `${{ github.token }}` (no PAT required for self-deploy). Embed `comet.svg` at the top of the profile README so the comet graph appears on the GitHub profile page. Coexists with Option A: A is automated regression (weekly cron in source repo); B is public showcase.
 
 ## Fixed design decisions (user-approved 2026-04-20)
 

--- a/docs_comet/project/devops/github-action-target.md
+++ b/docs_comet/project/devops/github-action-target.md
@@ -46,7 +46,7 @@ Publish a public GitHub Action that any developer installs in their profile repo
 
 ### Forward-referencing specs
 
-Specs for PR 003/004/005 are intentionally NOT written yet. Their scope will be refined by what we learn shipping PR 002 (actual SMIL behavior through camo, snapshot testing ergonomics, TS build quirks). Writing them now would be premature — they would rot before execution. Create each spec when its PR begins.
+Specs for PR 002–005 were written just-in-time at the start of each PR rather than up-front, so each scope reflected what we learned shipping earlier PRs. All four are now committed under `specs/`.
 
 ## Near-term follow-ups (post-PR-005)
 

--- a/scripts/check-static-baseline.mjs
+++ b/scripts/check-static-baseline.mjs
@@ -35,6 +35,7 @@ const requiredFiles = [
   ".github/workflows/ai-review.yml",
   ".github/workflows/ai-command-policy.yml",
   ".github/workflows/osv-scan.yml",
+  ".github/workflows/comet-graph.yml",
   ".github/dependabot.yml",
   "action.yml",
   ".gitattributes",

--- a/specs/005-dogfood/plan.md
+++ b/specs/005-dogfood/plan.md
@@ -1,0 +1,272 @@
+# Plan — Dogfood (workflow + README publish)
+
+## Approach
+
+Single-phase, four-file change. No new code, no new deps, no new tests. The whole PR is:
+
+1. One YAML workflow file.
+2. One README rewrite (surgical edits on top, new sections appended, dev sections retained).
+3. Two touches to existing files (target-doc sync + baseline-checker extension).
+4. One spec folder (this doc + tasks).
+
+The Action bundle, renderer, data layer, and entrypoint are frozen. This PR composes their already-shipped behavior into a live workflow and publishes a user-facing README — it does not alter how any of them behave.
+
+## Why not `/ralph` or `/ultrawork`
+
+- **`/ralph`**: no verification cycle worth looping — the single real validation (live workflow run) happens post-merge, outside the PR loop.
+- **`/ultrawork`**: 5 edits, 3 of which depend on spec decisions first — parallel decomposition saves ≈30 seconds while adding context overhead.
+- **Direct executor**: fixed decisions below eliminate all ambiguity; the task is mechanical edits + format + CI — right fit for a scoped executor + one code-reviewer pass before push.
+
+## Open-question resolutions
+
+The parent `/plan` request enumerated ten open questions. Resolutions, locked here so the executor does not reopen them:
+
+1. **Cron cadence** → `0 3 * * 1` (Monday 03:00 UTC, weekly) + `workflow_dispatch:`. Target-doc says "weekly + dispatch"; Monday 03:00 UTC is a low-traffic window.
+2. **Permissions scope** → Job-level `contents: write`. No other scopes needed.
+3. **Dogfood target repo** → **Option C strategy locked (A now, B next thread).** This PR = Option A: source-repo (`kiaquila/comet-contribution-graph`) workflow + source-repo embed. Rationale: zero-secrets via default `${{ github.token }}`, gives weekly auto-regression via cron, validates pipeline. Next-thread PR 006 = Option B: profile-repo (`kiaquila/kiaquila`) workflow via `uses: kiaquila/comet-contribution-graph@main`, uses profile-repo's own `${{ github.token }}` (no PAT needed), embeds in profile README for marketing-facing shopfront deployment. Both options coexist — A catches regressions, B is public demo.
+4. **README "Live demo" placement** → At the top (badges + image), Platane/snk-style catchy-effect.
+5. **`<picture>` reduced-motion variant** → Plain `<img>` in the live-demo; `<picture>` shown in "Usage → Reduced motion" as an opt-in block for consumers who want it.
+6. **target-doc sync** → Status section + roadmap-table annotations only; no architecture-contract edits. Squash SHAs recorded post-merge in a separate commit (out of PR scope).
+7. **Workflow YAML validation** → None pre-commit. Baseline `check:repo` file-exists gate + GitHub's own parser on first push is sufficient. Adding `action-validator` / `actionlint` for this PR is overkill (single workflow, no history of YAML bugs).
+8. **Feature-memory gate** → `specs/005-dogfood/{spec,plan,tasks}.md` committed in the same commit as the workflow + README changes, so the gate passes against the full PR diff.
+9. **Vercel preview** → No-op. No changes to `prototypes/` or `scripts/build-static.mjs`.
+10. **New CI scripts** → None. Keep CI surface stable; the baseline-checker extension is the only pipeline touch.
+
+## Step order
+
+### Step 1 — spec folder (this commit)
+
+Files produced: `specs/005-dogfood/spec.md`, `specs/005-dogfood/plan.md`, `specs/005-dogfood/tasks.md`.
+
+Reason it's first: `pnpm run check:feature-memory` runs against any staged product-path change, and the pre-push hook also enforces it. Both must see the spec folder present in the PR diff.
+
+### Step 2 — `.github/workflows/comet-graph.yml`
+
+Final content (shown verbatim so the executor doesn't reinvent it):
+
+```yaml
+name: comet-graph
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+concurrency:
+  group: comet-graph
+  cancel-in-progress: true
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          username: kiaquila
+```
+
+No `token` / `reduced` / `branch` overrides needed — `action.yml` defaults match what we want (`${{ github.token }}`, `"true"`, `"comet-graph"`).
+
+Notes for the executor:
+
+- `uses: ./` requires the checkout step to run first (so `action.yml` is on disk).
+- `concurrency.cancel-in-progress: true` is safe here because output is idempotent (force-push of the same-shape artifact).
+- `timeout-minutes: 5` cap is generous (empty-year ~30s; heavy-user ~90s per PR 004 data).
+
+### Step 3 — `scripts/check-static-baseline.mjs`
+
+Add `.github/workflows/comet-graph.yml` to `requiredFiles`. Single-line insertion after the existing `.github/workflows/osv-scan.yml` entry (alphabetical order not enforced; insertion at the bottom of the `.github/workflows/*` cluster keeps diff-readability).
+
+Regression test: temporarily `git mv` the workflow file aside → `pnpm run check:repo` exits 1 with `Missing required baseline files: - .github/workflows/comet-graph.yml` → restore.
+
+### Step 4 — `README.md` rewrite
+
+Approach: **one full rewrite via Write** rather than five surgical Edits. Reason: top-of-file restructure + two new sections + three edited sections = an Edit sequence large enough that a rewrite is simpler and less error-prone.
+
+Outline, top to bottom (see `spec.md` "README shape" for the full target outline):
+
+1. **Title** — `# comet-contribution-graph`
+2. **Tagline** (1 line, same message as current)
+3. **Badges** —
+   - `[![comet-graph](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/comet-graph.yml/badge.svg)](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/comet-graph.yml)`
+   - `[![OSV Scanner](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/osv-scan.yml/badge.svg)](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/osv-scan.yml)`
+   - `[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)`
+4. **Live demo** — single `<img>` pointing at `raw.githubusercontent.com/kiaquila/comet-contribution-graph/comet-graph/comet.svg` with `alt`. Markdown `![...](...)` form.
+5. **`## Usage`**
+   - Paragraph (2 lines) — where to install and what happens.
+   - YAML snippet (installation in a profile repo):
+
+     ```yaml
+     # .github/workflows/comet-graph.yml in <user>/<user>
+     name: comet-graph
+     on:
+       schedule:
+         - cron: "0 3 * * 1"
+       workflow_dispatch:
+     jobs:
+       render:
+         runs-on: ubuntu-latest
+         permissions:
+           contents: write
+         steps:
+           - uses: actions/checkout@v4
+           - uses: kiaquila/comet-contribution-graph@main
+             with:
+               username: <user>
+     ```
+
+     Note under snippet: "`v1` tag coming post-MVP; pin to `@main` or a commit SHA for reproducibility."
+
+   - **Embed in your profile README** — Markdown:
+
+     ```markdown
+     ![cinematic comet contribution graph](https://raw.githubusercontent.com/<user>/<user>/comet-graph/comet.svg)
+     ```
+
+   - **Reduced-motion fallback** (subsection) — HTML `<picture>`:
+
+     ```html
+     <picture>
+       <source
+         media="(prefers-reduced-motion: reduce)"
+         srcset="
+           https://raw.githubusercontent.com/<user>/<user>/comet-graph/comet-reduced.svg
+         "
+       />
+       <img
+         alt="cinematic comet contribution graph"
+         src="https://raw.githubusercontent.com/<user>/<user>/comet-graph/comet.svg"
+       />
+     </picture>
+     ```
+
+   - **Inputs** — table with `name` / `required` / `default` / `description` columns, four rows matching `action.yml`:
+     - `username` · required · — · "GitHub login to render the graph for"
+     - `token` · optional · `${{ github.token }}` · "PAT with `read:user` only if querying another user; default works for owner's own graph"
+     - `reduced` · optional · `"true"` · "Also emit `comet-reduced.svg` for `prefers-reduced-motion` fallback"
+     - `branch` · optional · `"comet-graph"` · "Output branch; force-pushed on every run"
+
+6. **`## How it works`** — 2–3 sentences:
+
+   > Every run fetches your GitHub contributions via the GraphQL API, passes them through a pure-TS SVG renderer (SMIL-animated comet tracing your most productive days across a constellation of your year), and force-pushes the result to an orphan `comet-graph` branch in this repo. Your profile README embeds the SVG via a stable `raw.githubusercontent.com` URL. See [github-action-target.md](./docs_comet/project/devops/github-action-target.md) for the architecture contract.
+
+7. **`## Concept`** — keep existing four bullets, no edits.
+8. **`## Stack`** — rewrite as product stack, not prototype stack:
+   - Node 20 GitHub Action, bundled single-file via `@vercel/ncc` (committed at `dist-action/index.js`)
+   - Pure-TypeScript SVG renderer (`src/renderer.ts`) with SMIL animation
+   - GitHub GraphQL `contributionsCollection` data source (`src/data.ts`)
+   - System `monospace` font (embed-safe, no CDN)
+   - Prototype (`prototypes/variant-d-grid-peaks.html`) — development preview, deployed to Vercel per-PR
+   - CI: GitHub Actions (`baseline-checks`, `guard`, `AI Review`, `OSV Scanner`, `comet-graph` dogfood)
+
+9. **`## Getting started`** — keep existing section.
+10. **`## Scripts`** — update table to add (keep existing rows):
+    - `pnpm run check:ts` — TypeScript strict-mode compile check
+    - `pnpm run build:action` — produce `dist-action/index.js` via ncc
+    - `pnpm run check:dist` — verify committed bundle matches source
+11. **`## Supply chain`** — keep existing section.
+12. **`## Repository layout`** — update tree to include `src/`, `dist-action/`, `action.yml`, note `specs/005-dogfood/` is live:
+
+    ```
+    comet-contribution-graph/
+    ├── src/                         # Pure-TS Action: renderer, data, entry
+    ├── dist-action/                 # Committed ncc bundle (Node 20 single-file)
+    ├── prototypes/                  # Standalone HTML prototype
+    │   └── variant-d-grid-peaks.html
+    ├── scripts/                     # Build and orchestration helpers
+    ├── tests/                       # Node test suites + fixtures + snapshots
+    ├── specs/<feature-id>/          # Per-feature spec.md / plan.md / tasks.md
+    ├── docs_comet/                  # Durable docs, ADRs, devops contracts
+    ├── .specify/memory/             # Constitution and process rules
+    ├── .github/workflows/           # CI, guard, AI review, OSV scan, dogfood
+    ├── action.yml                   # GitHub Action metadata
+    ├── vercel.json                  # Vercel build/output configuration
+    └── AGENTS.md / CLAUDE.md        # Agent onboarding
+    ```
+
+13. **`## Workflow`** — keep existing section (internal-dev workflow).
+14. **`## License`** — keep existing section.
+
+### Step 5 — `docs_comet/project/devops/github-action-target.md`
+
+Surgical edits:
+
+1. **Status section** (lines ~9–17): update
+   - "PR 004 — Action entrypoint — in review" → "PR 004 — Action entrypoint — MERGED (squash `7225f17`)"
+   - "PR 005 — not started; spec not yet written" → "PR 005 — dogfood workflow + README publish — in review"
+2. **Roadmap table** (lines ~38–43): annotate
+   - 002 row: " ✅ MERGED" suffix
+   - 003 row: " ✅ MERGED" suffix
+   - 004 row: replace "**In review.**" → "**✅ MERGED.**"
+   - 005 row: add "🚧 **In review.**" at end of description cell
+
+No other edits — architecture contract, fixed-design-decisions table, deferred list, action-inputs table, handoff protocol — all remain verbatim.
+
+### Step 6 — verification pass (local)
+
+Order matters here; each gate depends on prior steps:
+
+1. `pnpm run check:feature-memory` — spec folder present, gate passes on full PR diff `origin/main..HEAD`.
+2. `pnpm run check:repo` — baseline files all present (including new workflow).
+3. `pnpm run format:check` — prettier on new YAML + updated README + updated target-doc + updated baseline script.
+4. `pnpm run ci` end-to-end — confirms nothing else broke.
+5. Manual: `git diff origin/main -- src/ dist-action/ prototypes/ action.yml package.json pnpm-lock.yaml tsconfig.json` is empty (no bundle/src drift).
+6. Manual: `cat .github/workflows/comet-graph.yml` — visually confirm shape matches spec's "Workflow shape" block.
+
+### Step 7 — commit
+
+Single commit on this worktree: `feat(dogfood): comet-graph workflow + README publish (PR 005)`.
+
+Files staged:
+
+- `specs/005-dogfood/spec.md`
+- `specs/005-dogfood/plan.md`
+- `specs/005-dogfood/tasks.md`
+- `.github/workflows/comet-graph.yml`
+- `README.md`
+- `docs_comet/project/devops/github-action-target.md`
+- `scripts/check-static-baseline.mjs`
+
+### Step 8 — code-reviewer pass, then push + Codex review
+
+1. `code-reviewer` subagent on the full PR diff — focus: README inputs-table correctness vs `action.yml`, workflow permissions scope, embed URL spelling, cron syntax. (Low-risk PR; expect verdict APPROVE or minor suggestions.)
+2. `git push` → PR opened against `main`.
+3. `@codex review` via `gh pr comment` (per memory `feedback_codex_human_trigger`).
+4. Iterate on Codex findings — budget: 1–2 cycles for an S PR.
+5. After each push: repeat `@codex review` (per `feedback_codex_human_trigger`).
+
+## Validation order
+
+1. Step 1 (spec folder) → `pnpm run check:feature-memory` green.
+2. Step 2 (workflow YAML) → `node -e "JSON.stringify(require('yaml').parse(require('fs').readFileSync('.github/workflows/comet-graph.yml','utf8')))"` exits 0 (manual; not a CI gate).
+3. Step 3 (baseline extension) → `pnpm run check:repo` green with new workflow in required list; temporarily remove workflow → exit 1 with expected message → restore.
+4. Step 4 (README rewrite) → `pnpm run format:check` green.
+5. Step 5 (target-doc sync) → `pnpm run format:check` green.
+6. Step 6 (verification pass) → full `pnpm run ci` exit 0.
+7. Step 7 (commit) → `git log -1 --oneline` shows the conventional-format subject.
+8. Step 8 (push + review) → PR opened; `@codex review` comment posted; baseline + guard + AI Review all green on head SHA.
+
+## Risks
+
+- **README embed 404 pre-first-run.** Expected; bounded to ~60 seconds post-merge when `workflow_dispatch` populates the branch. If user wants zero broken state at any moment: bootstrap the branch manually before merging (one-shot `git checkout --orphan comet-graph && touch comet.svg && git push origin comet-graph`). Not in this plan — adds a pre-merge ceremony step.
+- **Cron timing overlaps external GitHub events.** `0 3 * * 1` is stable; GitHub may delay scheduled runs by minutes under load but will not skip them.
+- **`concurrency.cancel-in-progress: true` cancels manual dispatch mid-run if cron fires.** Unlikely (cron is weekly). Safe either way — the next run is idempotent.
+- **Workflow fails on first run due to empty branch.** `src/action.ts` uses `git checkout --orphan` regardless of remote state — it creates the branch if missing. Verified in PR 004.
+- **README badges reference a workflow that doesn't yet exist at merge time.** The badge URL resolves after the PR merges and GitHub registers the workflow. Shields.io-style "unknown" state until then. Acceptable.
+- **`uses: ./` on a runner that receives the checkout at a path other than `$GITHUB_WORKSPACE`.** All GitHub-hosted runners use `$GITHUB_WORKSPACE`; `actions/checkout@v4` respects it. No risk.
+- **Codex over-scrutiny on workflow YAML conventions.** Budget 1–2 cycles; per `feedback_codex_reimplement_tool_rules`, if Codex iterates on formatting minutiae, push back or defer.
+- **Pre-push hook blocks push if spec folder is staged in a separate commit.** This plan is a single commit, so no risk — `feedback_check_feature_memory_spec_coupling` pattern: keep spec + product changes in one commit.
+- **Vercel preview deploy fails because `README.md` is not a prototype change.** Vercel is scoped to `prototypes/` + `scripts/build-static.mjs`; README changes are no-op for the preview build. Verified in PR 002 shipping.
+
+## Out of bounds
+
+- No changes to `src/**`, `dist-action/**`, `prototypes/**`, `tests/**`, `action.yml`, `package.json`, `pnpm-lock.yaml`, `tsconfig.json`.
+- No new `.github/workflows/*.yml` beyond `comet-graph.yml`.
+- No new CI scripts.
+- No ESLint / html-validate / prettier config changes.
+- No dependabot / OSV config changes.
+- No LICENSE edits.
+- No `.gitignore` / `.gitattributes` edits.
+- No `.specify/memory/constitution.md` edits.
+- No changes to `AGENTS.md` or `CLAUDE.md` (dogfood scope already documented in target-doc).

--- a/specs/005-dogfood/spec.md
+++ b/specs/005-dogfood/spec.md
@@ -1,0 +1,156 @@
+# Feature 005 — Dogfood: comet-graph workflow + README publish
+
+## Goal
+
+Ship the first end-to-end run of the Action: a GitHub Actions workflow (`.github/workflows/comet-graph.yml`) that installs this very repo as an Action, runs it weekly + on-demand against the owner's own contributions, force-pushes the generated SVG(s) to the `comet-graph` branch; plus a README overhaul that documents installation for external users and embeds the live dogfood SVG at the top. After this PR merges and the workflow runs once (manual `workflow_dispatch`), anyone can reference `kiaquila/comet-contribution-graph@main` from a workflow in their own profile repo and have their comet graph published at `raw.githubusercontent.com/<user>/<user>/comet-graph/comet.svg`.
+
+## Why
+
+PR 004 shipped the installable Action bundle; until someone actually installs and runs it, we don't know whether the GraphQL fetch, rendering, and orphan push behave correctly end-to-end under real GitHub runner constraints (node 20 subset, public API rate limits, git config defaults, minimum-scope token). The dogfood workflow is the first real integration test — it takes a concrete input (kiaquila's real contributions) and produces a concrete artifact on a branch. It's the final PR in the 4-PR MVP roadmap; after this the repo is ready for external adoption (sans Marketplace listing, which stays post-MVP).
+
+## Dogfood strategy (Option C: A now, B next thread)
+
+This PR implements **Option A** — source-repo dogfood: workflow lives in this repo, runs Action via `uses: ./`, pushes SVG to this repo's `comet-graph` branch, embeds in this repo's README. Validates the Action pipeline automatically via weekly cron; acts as regression guard.
+
+A follow-up **PR 006 (next thread)** will implement **Option B** — profile-repo dogfood: workflow in `kiaquila/kiaquila` installs the Action via `uses: kiaquila/comet-contribution-graph@main`, pushes to the profile repo's own `comet-graph` branch via the profile repo's default `${{ github.token }}` (no PAT needed), embeds in the profile README so the comet graph shows on the GitHub profile page itself. That's the marketing-facing "shopfront" deployment.
+
+Both options use the built-in `${{ github.token }}`; the difference is which repo the workflow lives in. Option A is auto-regression + tech demo; Option B is public showcase. Neither blocks the other.
+
+## Scope
+
+**In scope** (fourth of four PRs toward MVP Action)
+
+- `.github/workflows/comet-graph.yml` — dogfood workflow with:
+  - `on: schedule: - cron: '0 3 * * 1'` (Monday 03:00 UTC) + `on: workflow_dispatch:`
+  - single `render` job, `runs-on: ubuntu-latest`, `timeout-minutes: 5`, `permissions: { contents: write }`
+  - `concurrency: { group: comet-graph, cancel-in-progress: true }` to avoid parallel runs stomping the output branch
+  - steps: `uses: actions/checkout@v4` then `uses: ./` with `with: { username: kiaquila }`
+- `README.md` — full overhaul:
+  - Top-of-file: title + 1-line tagline + badges row (comet-graph workflow status + OSV + license) + live-demo `<img>` embed from this repo's `comet-graph` branch.
+  - New `## Usage` section — install-in-profile-repo YAML snippet, profile-README embed snippet (plain `<img>`), optional `<picture>` reduced-motion fallback as a subsection, inputs table matching `action.yml` verbatim.
+  - New `## How it works` section — 2–3 sentence dataflow (GraphQL → pure-TS SVG renderer → orphan force-push) with link to `docs_comet/project/devops/github-action-target.md`.
+  - Retain (with minor edits): `## Concept`, `## Stack`, `## Getting started`, `## Scripts`, `## Supply chain`, `## Repository layout`, `## Workflow` (internal-dev), `## License`.
+  - Remove: "Work in progress — private preview" banner; "No product `index.html` yet" line; "Final deliverable: a published GitHub Action" phrasing (it's shipped now).
+- `docs_comet/project/devops/github-action-target.md`:
+  - Status section: mark PR 004 as MERGED (squash `7225f17`); mark PR 005 as "in review".
+  - Roadmap table: annotate rows 002/003/004 as merged; 005 as in review.
+  - No architecture-contract edits — everything is already documented there.
+- `scripts/check-static-baseline.mjs` — append `.github/workflows/comet-graph.yml` to `requiredFiles` so future edits can't silently drop the dogfood workflow.
+
+**Out of scope** (deferred)
+
+- Running the workflow in CI-gated pre-merge mode — GitHub does not permit a workflow file to run on the PR that introduces it; first real execution happens after merge via `workflow_dispatch`.
+- Marketplace listing + `v1` Action tag — post-MVP per target-doc.
+- Profile-repo (`kiaquila/kiaquila`) workflow — **next-thread follow-up PR 006 (Option B of the Option C dogfood strategy)**. Uses profile-repo's own `${{ github.token }}`, no PAT needed. Embeds at the top of the GitHub profile page.
+- GIF output (Puppeteer) — post-MVP.
+- Cross-user PAT UX in docs beyond mentioning that a PAT is required — post-MVP.
+- Playground / landing page — post-MVP.
+- `remark-lint` / markdown link-checker tooling — GitHub-side rendering is enough for MVP.
+- `check:workflows` YAML parser — GitHub validates on push; adds no value pre-merge.
+
+## Constraints
+
+- **Self-install reference.** Workflow uses `uses: ./` after `actions/checkout@v4`, not a versioned tag. `v1` release happens post-MVP; chicken-and-egg otherwise (tag requires first green run; first run requires workflow on `main`).
+- **Minimum-scope permissions.** `permissions: contents: write` declared at job level, not workflow level. No `actions`, `pull-requests`, `issues`, `packages`, `id-token`.
+- **Single output branch.** The workflow pushes to the same `kiaquila/comet-contribution-graph` repo's `comet-graph` branch via the Action's built-in `${{ github.token }}` default. No PAT needed for MVP.
+- **Prototype + renderer + data + entry + bundle byte-identical.** `prototypes/variant-d-grid-peaks.html`, `src/**`, `dist-action/**`, `action.yml`, `tsconfig.json`, `package.json`, `pnpm-lock.yaml` — zero changes. This PR is workflow + docs only.
+- **README embed URL stable.** `https://raw.githubusercontent.com/kiaquila/comet-contribution-graph/comet-graph/comet.svg` — no `?v=...` cache-bust in the repo's own README (documented pattern for external users only).
+- **Transient 404 on first render.** Until the first `workflow_dispatch` completes, `comet.svg` does not exist on `comet-graph` branch → README image 404s. Acceptable: post-merge manual trigger populates it within ~60 seconds.
+- **CI green end-to-end.** `check:repo` picks up the new workflow (baseline), `format:check` covers `.yml` + `.md`, `check:ts`/`check:js`/`check:html`/`test`/`build`/`build:action`/`check:dist` untouched.
+- **Feature-memory gate green.** `specs/005-dogfood/{spec,plan,tasks}.md` committed in this PR.
+- **Commit-message style** per CLAUDE.md: subject only, ≤72 chars, `feat(dogfood):` prefix.
+
+## Validation
+
+- `pnpm run ci` green end-to-end locally.
+- `pnpm run check:feature-memory` green.
+- `node -e "const p = require('yaml').parse(require('fs').readFileSync('.github/workflows/comet-graph.yml','utf8')); console.log(p.jobs.render.permissions)"` (or similar) parses the workflow and prints expected permissions — manual check, not a CI gate.
+- `pnpm run format:check` passes on new YAML + updated README.
+- `git diff origin/main -- src/ dist-action/ prototypes/ action.yml package.json pnpm-lock.yaml tsconfig.json` is empty.
+- PR diff touches only: `specs/005-dogfood/**`, `.github/workflows/comet-graph.yml`, `README.md`, `docs_comet/project/devops/github-action-target.md`, `scripts/check-static-baseline.mjs`.
+- **Post-merge (out-of-PR scope)**: `gh workflow run comet-graph.yml` → observe run success → `git fetch origin comet-graph && git ls-tree origin/comet-graph` lists `comet.svg` + `comet-reduced.svg` → README live-demo image resolves in GitHub preview.
+
+## Acceptance
+
+- `.github/workflows/comet-graph.yml` exists, valid YAML, schedule + dispatch triggers, `permissions.contents: write` at job level, uses `./` with `username: kiaquila` input.
+- `README.md`: "Work in progress" banner gone; new "Usage" + "How it works" sections present; live-demo embed + badges visible at top; inputs table matches `action.yml` exactly; `<picture>` reduced-motion fallback documented.
+- `docs_comet/project/devops/github-action-target.md` Status section reflects 004 MERGED and 005 in review.
+- `scripts/check-static-baseline.mjs` includes `.github/workflows/comet-graph.yml` in `requiredFiles`; temporarily removing the workflow file makes `pnpm run check:repo` exit 1.
+- `specs/005-dogfood/{spec,plan,tasks}.md` present and internally consistent; feature-memory gate green.
+- `pnpm run ci` green end-to-end locally.
+- Single commit on the branch with conventional subject.
+
+## Workflow shape (final, subject to user approval)
+
+```yaml
+name: comet-graph
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+concurrency:
+  group: comet-graph
+  cancel-in-progress: true
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          username: kiaquila
+```
+
+No `token`, `reduced`, `branch` overrides — the Action defaults (from `action.yml`) match what we want: `${{ github.token }}`, `reduced=true`, `branch=comet-graph`.
+
+## README shape (target outline)
+
+1. `# comet-contribution-graph` — title
+2. Tagline (1 line, same message as current first line)
+3. Badges row: workflow status + OSV + license
+4. Live-demo `<img>` from `comet-graph` branch
+5. `## Usage` — YAML install snippet, embed snippet, reduced-motion variant, inputs table
+6. `## How it works` — 2–3 sentences + link to target-doc
+7. `## Concept` — existing content, minor phrasing cleanup
+8. `## Stack` — updated: "Node 20 GitHub Action (pure-TS SVG renderer, SMIL animation)", prototype demoted to "development preview"
+9. `## Getting started` — existing, unchanged
+10. `## Scripts` — table updated with `build:action`, `check:dist`, `check:ts`
+11. `## Supply chain` — existing, unchanged
+12. `## Repository layout` — updated tree: adds `src/`, `dist-action/`, `action.yml`
+13. `## Workflow` — internal-dev, existing, unchanged
+14. `## License` — existing, unchanged
+
+## Fixed design decisions (user-to-approve before executor runs)
+
+| Decision                      | Value                                                                                                                 | Rationale                                                                                                                                                                 |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Dogfood target repo (this PR) | **This repo** (`kiaquila/comet-contribution-graph`), `comet-graph` branch — Option A of the Option C dogfood strategy | Default `${{ github.token }}` works with zero secrets setup. Provides weekly auto-regression via cron. Option B (profile-repo `kiaquila/kiaquila`) is next-thread PR 006. |
+| Embed URL                     | `https://raw.githubusercontent.com/kiaquila/comet-contribution-graph/comet-graph/comet.svg`                           | Matches dogfood-target decision; stable; camo-cacheable.                                                                                                                  |
+| Cron schedule                 | `0 3 * * 1` (Monday 03:00 UTC)                                                                                        | Low-traffic window; weekly aligns with real contribution cadence.                                                                                                         |
+| `workflow_dispatch`           | Enabled                                                                                                               | Manual retrigger for post-merge bootstrap + ad-hoc refresh.                                                                                                               |
+| Action ref in workflow        | `uses: ./` after `actions/checkout@v4`                                                                                | Self-reference; avoids chicken-egg with `v1` tag before first green run. External users get `kiaquila/comet-contribution-graph@main` snippet in Usage docs.               |
+| Permissions                   | Job-level `contents: write`                                                                                           | Minimum viable; no other scopes needed for orphan push.                                                                                                                   |
+| Concurrency                   | `group: comet-graph, cancel-in-progress: true`                                                                        | Prevents parallel runs racing on the output branch (weekly + manual dispatch can overlap).                                                                                |
+| Job timeout                   | `timeout-minutes: 5`                                                                                                  | Empty-year run completes in <60s; heavy-user in <90s (per 004 spec). 5-min ceiling catches stuck runs without flakiness.                                                  |
+| README embed shape            | Plain `<img>` in live-demo; `<picture>` in "Usage → Reduced motion" subsection                                        | Simpler default; reduced-motion users get optional block. Matches target-doc pattern.                                                                                     |
+| Transient 404 pre-first-run   | Accepted                                                                                                              | Broken image for ~60s post-merge until `workflow_dispatch` populates the branch. Badge still renders workflow status.                                                     |
+| Badges                        | Comet-graph workflow status + OSV-scan + MIT license                                                                  | Surfaces render health + security + licensing at a glance.                                                                                                                |
+| Workflow YAML validation      | None pre-commit; rely on baseline file-exists + GitHub-side parser on first push                                      | `action-validator` / `actionlint` adds tooling for zero new bug-class coverage in MVP.                                                                                    |
+| Tests                         | No new test files                                                                                                     | Orchestration covered by `tests/action.test.mjs` (PR 004); workflow YAML is declarative config; README is doc-only.                                                       |
+| target-doc SHA for 005        | `TBD` in PR; post-merge update is out-of-PR scope                                                                     | Squash SHA is unknown before merge.                                                                                                                                       |
+| Commit strategy               | Single commit on the worktree, spec + workflow + README + docs together                                               | Matches PR 003/004 discipline.                                                                                                                                            |
+| Commit subject                | `feat(dogfood): comet-graph workflow + README publish (PR 005)`                                                       | ≤72 chars, conventional prefix.                                                                                                                                           |
+
+## Non-goals
+
+- **No "run the workflow before merge" gate.** GitHub does not run a workflow file from a PR checkout on workflow-level events; first real run happens post-merge.
+- **No cross-user testing matrix.** Dogfood is for `username: kiaquila`; external-user correctness is covered by existing unit tests on `fetchContributions` + renderer.
+- **No `act`/Docker-based integration test for the workflow.** MVP relies on Action unit tests (PR 004) + the first live run post-merge.
+- **No retry/alert on render failure.** `setFailed` flips the workflow run state red; GitHub emails the repo owner. No PagerDuty-style escalation for MVP.
+- **No notification on successful render.** GitHub run history is enough for dogfood visibility.
+- **No commit-signing on the orphan push.** Uses the Action's built-in identity (`comet-graph-bot`, set in `src/action.ts`).
+- **No multi-language README / i18n.** English only.
+- **No image-diff regression gate for the rendered SVG.** Snapshot tests (PR 002) cover renderer behavior at code level; human-eyeball is the MVP gate for real-data output.

--- a/specs/005-dogfood/tasks.md
+++ b/specs/005-dogfood/tasks.md
@@ -1,0 +1,137 @@
+# Tasks — Dogfood (workflow + README publish)
+
+## Spec folder (this commit)
+
+- [ ] `specs/005-dogfood/spec.md` — written (this task is complete if the file exists and matches the spec in this PR)
+- [ ] `specs/005-dogfood/plan.md` — written
+- [ ] `specs/005-dogfood/tasks.md` — written (this file)
+
+## Workflow file
+
+- [ ] Create `.github/workflows/comet-graph.yml` with:
+  - [ ] `name: comet-graph`
+  - [ ] `on.schedule: - cron: "0 3 * * 1"`
+  - [ ] `on.workflow_dispatch: {}`
+  - [ ] `concurrency: { group: comet-graph, cancel-in-progress: true }`
+  - [ ] `jobs.render.runs-on: ubuntu-latest`
+  - [ ] `jobs.render.timeout-minutes: 5`
+  - [ ] `jobs.render.permissions: { contents: write }` (job-level, not workflow-level)
+  - [ ] Step 1: `uses: actions/checkout@v4`
+  - [ ] Step 2: `uses: ./` with `with: { username: kiaquila }` (other inputs default)
+  - [ ] 2-space indent throughout, no tabs; trailing newline
+- [ ] Verify YAML parses by pasting into any YAML linter or `node --input-type=module -e "import('yaml').then(m=>console.log(m.parse(require('fs').readFileSync('.github/workflows/comet-graph.yml','utf8'))))"`
+
+## Baseline gate extension
+
+- [ ] Open `scripts/check-static-baseline.mjs`
+- [ ] Append `".github/workflows/comet-graph.yml"` to the `requiredFiles` array (alongside the other `.github/workflows/*` entries)
+- [ ] Verify: temporarily `mv .github/workflows/comet-graph.yml /tmp/` → `pnpm run check:repo` exits 1 with `- .github/workflows/comet-graph.yml` in the missing-files list → restore
+
+## README rewrite
+
+- [ ] Overwrite `README.md` (single `Write` call; Edit sequence is too fragmented for this scope)
+- [ ] Top-of-file order:
+  - [ ] `# comet-contribution-graph`
+  - [ ] Tagline: "A cinematic GitHub contribution graph. A comet traces your most productive days across a constellation of your year."
+  - [ ] Badges row (3 badges; single line, markdown):
+    - [ ] `[![comet-graph](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/comet-graph.yml/badge.svg)](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/comet-graph.yml)`
+    - [ ] `[![OSV Scanner](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/osv-scan.yml/badge.svg)](https://github.com/kiaquila/comet-contribution-graph/actions/workflows/osv-scan.yml)`
+    - [ ] `[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)`
+  - [ ] Live demo image (Markdown form): `![cinematic comet contribution graph](https://raw.githubusercontent.com/kiaquila/comet-contribution-graph/comet-graph/comet.svg)`
+- [ ] Remove "Work in progress — private preview" line entirely
+- [ ] Remove "No product `index.html` yet — the prototype is the working artifact." line
+- [ ] Rephrase "Final deliverable: a published GitHub Action..." → "This repo ships the public Action..."
+- [ ] Add `## Usage` section with:
+  - [ ] 2-line intro (where to install, what happens)
+  - [ ] YAML snippet for profile-repo workflow, using `kiaquila/comet-contribution-graph@main` and `username: <user>` placeholder (match the workflow shape from spec; permissions at job level)
+  - [ ] Note line: "`v1` tag coming post-MVP; pin to `@main` or a commit SHA for reproducibility."
+  - [ ] "Embed in your profile README" subsection with Markdown `<img>` snippet (user/user/comet-graph/comet.svg)
+  - [ ] "Reduced-motion fallback" subsection with `<picture>` snippet (comet-reduced.svg + comet.svg)
+  - [ ] "Inputs" subsection — table with columns `name | required | default | description`, four rows verbatim from `action.yml`:
+    - [ ] `username` · required · — · "GitHub login to render the graph for"
+    - [ ] `token` · optional · `${{ github.token }}` · "PAT with `read:user` only if querying another user; default works for owner's own graph"
+    - [ ] `reduced` · optional · `"true"` · "Also emit `comet-reduced.svg` for `prefers-reduced-motion` fallback"
+    - [ ] `branch` · optional · `"comet-graph"` · "Output branch; force-pushed on every run"
+- [ ] Add `## How it works` section (2–3 sentences about dataflow, link to target-doc)
+- [ ] Retain `## Concept` section verbatim
+- [ ] Rewrite `## Stack` section to reflect Node 20 Action + pure-TS renderer + SMIL + GraphQL data source + prototype-as-preview + CI (5–6 bullets)
+- [ ] Retain `## Getting started` section verbatim
+- [ ] Update `## Scripts` table — add rows for `check:ts`, `build:action`, `check:dist` (keep existing rows)
+- [ ] Retain `## Supply chain` section verbatim
+- [ ] Update `## Repository layout` tree to include `src/`, `dist-action/`, `action.yml` (see plan for exact tree)
+- [ ] Retain `## Workflow` (internal-dev) section verbatim
+- [ ] Retain `## License` section verbatim (with 2026 Kristina Aquila attribution)
+- [ ] Final sanity: all markdown links resolve to real paths (`./LICENSE`, `./AGENTS.md`, `./docs_comet/README.md`, `./docs_comet/project/devops/github-action-target.md`)
+- [ ] Run `pnpm run format:check` — prettier must be happy; if it complains, apply `pnpm exec prettier --write README.md` before recommitting
+
+## target-doc sync
+
+- [ ] Open `docs_comet/project/devops/github-action-target.md`
+- [ ] Status section — update 004 row: "in review" → "MERGED (squash `7225f17`)"
+- [ ] Status section — update 005 row: "not started; spec not yet written" → "dogfood workflow + README publish (Option A of Option C dogfood strategy) — in review"
+- [ ] Roadmap table row 002 — append " ✅ MERGED" to description cell
+- [ ] Roadmap table row 003 — append " ✅ MERGED" to description cell
+- [ ] Roadmap table row 004 — replace `**In review.**` with `**✅ MERGED.**`
+- [ ] Roadmap table row 005 — append `🚧 **In review.**` to description cell
+- [ ] Add a new subsection `## Near-term follow-ups (post-PR-005)` below the "4-PR roadmap" section (before "Fixed design decisions"), containing one bulleted entry:
+  - **PR 006 — profile-repo dogfood (Option B of Option C strategy).** Install the Action in `kiaquila/kiaquila` profile repo via `uses: kiaquila/comet-contribution-graph@main`; push SVG to the profile repo's own `comet-graph` branch using that repo's default `${{ github.token }}` (no PAT required for self-deploy). Embed `comet.svg` at the top of the profile README so the comet graph appears on the GitHub profile page. Coexists with Option A: A is automated regression (weekly cron in source repo); B is public showcase.
+- [ ] Do NOT touch architecture contract, fixed-design-decisions, deferred list, action-inputs table, handoff protocol — all verbatim
+- [ ] Run `pnpm run format:check` on the updated file
+
+## Verification (local)
+
+- [ ] `pnpm run check:feature-memory` — green (spec folder in PR diff)
+- [ ] `pnpm run check:repo` — green (baseline incl. new workflow)
+- [ ] `pnpm run check:html` — green (prototype untouched)
+- [ ] `pnpm run check:js` — green (no JS changes)
+- [ ] `pnpm run check:ts` — green (no TS changes)
+- [ ] `pnpm run build` — green
+- [ ] `pnpm run build:action` — green (no src/action.ts changes → ncc output byte-stable)
+- [ ] `pnpm run check:dist` — green (committed bundle matches source)
+- [ ] `pnpm run format:check` — green (prettier on README + YAML + target-doc + baseline.mjs)
+- [ ] `pnpm test` — green (existing tests, unchanged)
+- [ ] `pnpm run ci` — green end-to-end
+- [ ] `git diff origin/main -- src/ dist-action/ prototypes/ action.yml package.json pnpm-lock.yaml tsconfig.json` — empty
+- [ ] PR diff touches only: `specs/005-dogfood/**`, `.github/workflows/comet-graph.yml`, `README.md`, `docs_comet/project/devops/github-action-target.md`, `scripts/check-static-baseline.mjs`
+
+## Code-reviewer + PR + review cycles
+
+- [ ] `code-reviewer` subagent pass on full PR diff — focus:
+  - [ ] README inputs table exactly matches `action.yml` input names, requiredness, defaults, descriptions
+  - [ ] Workflow permissions are declared at job level (not workflow level)
+  - [ ] Embed URL spelling consistent across live-demo, Usage embed snippet, reduced-motion fallback
+  - [ ] Cron syntax `0 3 * * 1` is Monday 03:00 UTC (not Sunday — day-of-week starts at 0=Sunday in cron, 1=Monday)
+  - [ ] YAML indentation consistent (2 spaces)
+  - [ ] No typos in "kiaquila" repo handle
+- [ ] Single commit: `feat(dogfood): comet-graph workflow + README publish (PR 005)` (subject only, no body unless reviewer surfaces a why)
+- [ ] Pre-push hook passes (`check-feature-memory-on-push.sh`)
+- [ ] `git push -u origin claude/practical-archimedes-fcfbdd`
+- [ ] `gh pr create --title "feat(dogfood): comet-graph workflow + README publish (PR 005)" --body-file <filename>` with summary + test plan
+- [ ] `gh pr comment <pr#> --body "@codex review"` (per memory `feedback_codex_human_trigger`)
+- [ ] After each subsequent push (fix cycle): repeat `@codex review`
+- [ ] `baseline-checks`, `guard`, `AI Review` green on PR head SHA
+- [ ] Vercel preview green (no-op — prototype unchanged)
+- [ ] All blocking Codex findings (`P0`–`P2`) resolved; verdict from Codex summary comment, not inline-comment count (per memory `feedback_codex_inline_pinned_to_head`)
+- [ ] PR merged via squash
+
+## Post-merge (out-of-PR-scope — for the user to run, not executor)
+
+- [ ] `gh workflow run comet-graph.yml --repo kiaquila/comet-contribution-graph` — manual first dispatch
+- [ ] Observe run completion (<2 min)
+- [ ] `git fetch origin comet-graph && git ls-tree origin/comet-graph` — lists `comet.svg` + `comet-reduced.svg`
+- [ ] Open this repo's README on GitHub — live-demo image resolves (no more 404)
+- [ ] `curl -sI https://raw.githubusercontent.com/kiaquila/comet-contribution-graph/comet-graph/comet.svg` — `200 OK`
+
+## Out of scope (deferred)
+
+- [ ] `v1` Action tag + release notes — post-MVP
+- [ ] Marketplace listing — post-MVP
+- [ ] Profile-repo (`kiaquila/kiaquila`) workflow — **next-thread PR 006 (Option B of Option C dogfood strategy)**; no PAT needed — uses profile repo's own `${{ github.token }}`
+- [ ] GIF output variant — post-MVP (Puppeteer ~150MB)
+- [ ] Playground / landing page — post-MVP
+- [ ] Cross-user PAT UX beyond the "token input" row in the README inputs table — post-MVP
+- [ ] `act` / Docker-based integration test — rely on PR 004 action unit tests + first live run post-merge
+- [ ] `remark-lint` / `markdown-link-check` tooling — GitHub rendering is sufficient MVP-gate
+- [ ] `actionlint` / `action-validator` — GitHub native YAML parser catches syntax errors on push
+- [ ] Post-merge: update target-doc with 005 squash SHA — separate commit, not in this PR
+- [ ] Image-diff regression gate for rendered SVG — renderer snapshot tests (PR 002) cover code-level correctness


### PR DESCRIPTION
## Summary

Final MVP PR — source-repo dogfood (Option A of Option C dogfood strategy).

- `.github/workflows/comet-graph.yml` — weekly cron `0 3 * * 1` + `workflow_dispatch`; `uses: ./` with `username: kiaquila`; job-scope `contents: write`; 5-min timeout; concurrency-guarded.
- `README.md` overhauled: badges + live-demo + `## Usage` (install snippet, embed, reduced-motion `<picture>`, inputs table matching `action.yml`) + `## How it works`; updated Stack + Scripts + Repository layout.
- `docs_comet/project/devops/github-action-target.md` synced: PR 004 MERGED (`7225f17`); PR 005 in review; new `## Near-term follow-ups` subsection flags PR 006 (profile-repo Option B, next thread); stale "Forward-referencing specs" note refreshed.
- `scripts/check-static-baseline.mjs` guards the new workflow file from silent deletion.

Spec: `specs/005-dogfood/{spec,plan,tasks}.md`.

Branch has 3 commits (squash-merge will collapse): initial feat + code-reviewer P1+P2 README fixes + P2-3 target-doc polish.

## Test plan

- [ ] CI green (\`baseline-checks\`, \`guard\`, \`AI Review\`)
- [ ] Vercel preview no-op (prototype unchanged)
- [ ] \`@codex review\` pass
- [ ] Post-merge: \`gh workflow run comet-graph.yml\` bootstraps \`comet-graph\` branch; README live-demo URL resolves