### PR TITLE
chore: migrate Action runtime to Node 24 + bump checkout@v6

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/comet-graph.yml
+++ b/.github/workflows/comet-graph.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./
         with:
           username: kiaquila

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: kiaquila/comet-contribution-graph@main
         with:
           username: <user>

--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     required: false
     default: "comet-graph"
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist-action/index.js"

--- a/docs_comet/project/devops/github-action-target.md
+++ b/docs_comet/project/devops/github-action-target.md
@@ -88,7 +88,7 @@ GitHub GraphQL API: `user(login: $login) { contributionsCollection { contributio
 
 ### Rendering
 
-Pure TypeScript in `src/renderer.ts` → SVG string. No DOM, no `document`, no `requestAnimationFrame`, no `canvas`. Runs on Node 20 stdlib only. Deterministic for a given `(data, options, seed)` tuple.
+Pure TypeScript in `src/renderer.ts` → SVG string. No DOM, no `document`, no `requestAnimationFrame`, no `canvas`. Runs on Node 24 stdlib only. Deterministic for a given `(data, options, seed)` tuple.
 
 ### Animation
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@actions/exec": "^1.1.1"
   },
   "devDependencies": {
-    "@types/node": "^20.19.39",
+    "@types/node": "^24.0.0",
     "@vercel/ncc": "^0.38.0",
     "eslint": "^9",
     "eslint-plugin-html": "^8",
@@ -40,7 +40,7 @@
   },
   "packageManager": "pnpm@10.33.0",
   "engines": {
-    "node": ">=20",
+    "node": ">=24",
     "pnpm": ">=10.16"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@types/node':
-        specifier: ^20.19.39
-        version: 20.19.39
+        specifier: ^24.0.0
+        version: 24.12.2
       '@vercel/ncc':
         specifier: ^0.38.0
         version: 0.38.4
@@ -138,8 +138,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@20.19.39':
-    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -676,8 +676,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
@@ -806,9 +806,9 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@20.19.39':
+  '@types/node@24.12.2':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.16.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -1297,7 +1297,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@6.21.0: {}
+  undici-types@7.16.0: {}
 
   undici@6.25.0: {}
 

--- a/specs/chore-node24-migration/plan.md
+++ b/specs/chore-node24-migration/plan.md
@@ -1,0 +1,24 @@
+# Plan — chore-node24-migration
+
+## Steps
+
+1. Update `action.yml` runtime `using: "node20"` → `"node24"`
+   → verify: grep confirms no `node20` in `action.yml`
+
+2. Bump `actions/checkout` to `@v6` in all workflow files
+   → verify: no `checkout@v4` references remain in `.github/workflows/`
+
+3. Update `package.json` — `engines.node` and `@types/node` to Node 24
+   → verify: `pnpm install` succeeds; lockfile updated
+
+4. Rebuild `dist-action/index.js` via `pnpm run build`
+   → verify: `pnpm run check:dist` exits 0 (byte-identical)
+
+5. Update `README.md` usage snippet and `docs_comet/project/devops/github-action-target.md`
+   → verify: no Node 20 / checkout@v4 references remain in docs
+
+6. Create `specs/chore-node24-migration/` feature memory (this folder)
+   → verify: `check:feature-memory` gate passes
+
+7. Run full `pnpm run ci`
+   → verify: all checks green

--- a/specs/chore-node24-migration/spec.md
+++ b/specs/chore-node24-migration/spec.md
@@ -1,0 +1,37 @@
+# Feature chore-node24-migration — Migrate Action runtime to Node 24
+
+## Goal
+
+Update the GitHub Action runtime declaration from Node 20 to Node 24 and align
+all related tooling (checkout action, type definitions, engine field) to match.
+
+## Why
+
+GitHub is deprecating Node 20 Actions. Starting 2026-06-02, Node 24 will be
+the forced default. The deprecation warning appeared during the PR 006
+bootstrap run on `kiaquila/kiaquila`. CI already runs on Node 24 via
+`actions/setup-node`; this PR makes the Action runtime declaration match reality.
+
+## Scope
+
+**In scope**
+
+- `action.yml` — `using: "node20"` → `"node24"`
+- `.github/workflows/comet-graph.yml` — `actions/checkout@v4` → `@v6`
+- `.github/workflows/ai-review.yml` — `actions/checkout@v4` → `@v6`
+- `package.json` — `engines.node` `>=20` → `>=24`; `@types/node` `^20` → `^24`
+- `pnpm-lock.yaml` — regenerated after dep bump
+- `README.md` — Usage snippet `checkout@v4` → `@v6`
+- `docs_comet/project/devops/github-action-target.md` — update Node version reference
+- `dist-action/index.js` — rebuilt via `ncc build`; `check:dist` verifies byte-identity
+
+**Out of scope**
+
+- Any runtime behavior changes (pure version declaration update)
+- `v1` tag (follow-up after merge)
+
+## Acceptance criteria
+
+- `pnpm run ci` fully green (all 78 tests pass, `check:dist` byte-identical)
+- No Node 20 references remain in `action.yml` or workflow files
+- `check:feature-memory` passes

--- a/specs/chore-node24-migration/tasks.md
+++ b/specs/chore-node24-migration/tasks.md
@@ -1,0 +1,14 @@
+# Tasks — chore-node24-migration
+
+- [x] Update `action.yml`: `using: "node20"` → `"node24"`
+- [x] Bump `actions/checkout@v4` → `@v6` in `comet-graph.yml`
+- [x] Bump `actions/checkout@v4` → `@v6` in `ai-review.yml`
+- [x] Update `package.json` `engines.node` to `>=24`
+- [x] Update `@types/node` to `^24.0.0` in `package.json`
+- [x] Run `pnpm install` to regenerate lockfile
+- [x] Rebuild `dist-action/index.js` via `ncc build`
+- [x] Verify `pnpm run check:dist` byte-identical
+- [x] Update `README.md` usage snippet (`checkout@v4` → `@v6`)
+- [x] Update `docs_comet/project/devops/github-action-target.md`
+- [x] Verify `pnpm run ci` fully green (78 tests, check:dist)
+- [x] Create feature-memory spec files (`spec.md`, `plan.md`, `tasks.md`)


### PR DESCRIPTION
## Summary
Addresses GitHub's Node 20 deprecation warning surfaced during PR 006 bootstrap run on `kiaquila/kiaquila`:
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20: `actions/checkout@v4`, `kiaquila/comet-contribution-graph@main`. Actions will be forced to Node 24 by default starting 2026-06-02.

### Changes
- `action.yml` — `using: "node20"` → `"node24"` (valid spec value; verified via `actions/checkout@v6.0.2/action.yml`).
- `.github/workflows/comet-graph.yml` — `actions/checkout@v4` → `@v6` (Node 24 native).
- `.github/workflows/ai-review.yml` — same bump (last remaining `@v4` in repo).
- `package.json` — `engines.node: ">=20"` → `">=24"`; `@types/node: ^20.19.39` → `^24.0.0` (resolved to 24.12.2).
- `pnpm-lock.yaml` — regenerated.
- `README.md` Usage snippet — `checkout@v4` → `@v6`.
- `docs_comet/project/devops/github-action-target.md` — "Node 20 stdlib" → "Node 24 stdlib".
- `dist-action/index.js` — rebuilt via `ncc build`; check:dist verifies byte-identity.

### Context
- CI already uses Node 24 (`actions/setup-node@v4` with `node-version: "24"` in `ci.yml` and `pr-guard.yml`), so the Action has been de-facto tested on Node 24. This PR makes the runtime declaration match.
- Prep for `v1` tag — tagging the merge commit with `v1` after this lands.

## Test plan
- [x] `pnpm run ci` green locally (78 tests pass, `check:dist` byte-identical)
- [x] `pnpm run check:feature-memory` passes (no product paths changed)
- [ ] CI + AI Review green on PR
- [ ] Source-repo dogfood cron (`comet-graph.yml`) exercises Node 24 runtime after merge
- [ ] Follow-up: tag `v1`, then separate tiny PR in `kiaquila/kiaquila` to pin `@main` → `@v1` + `@v4` → `@v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)