### PR TITLE
fix(ci): pin gate workflows to trusted base branch (011)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -56,9 +56,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Checkout
+      - name: Checkout trusted base (gate code never comes from PR head)
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
 
       - name: Resolve PR context

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -32,11 +32,18 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Checkout
+      - name: Checkout trusted base (gate code never comes from PR head)
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Fetch PR head SHA for read-only diff/cat-file probes
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=200 origin "${{ github.event.pull_request.head.sha }}"
 
       - name: Resolve diff refs
         shell: bash

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -43,7 +43,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=200 origin "${{ github.event.pull_request.head.sha }}"
+          # No --depth cap: the trusted-base checkout above already pulls
+          # main's full history (fetch-depth: 0), so this fetch only
+          # adds the PR-side commits up to the merge-base and stops. A
+          # fixed shallow cap would silently drop the merge-base for
+          # long-lived PR branches and break `git diff $BASE...$HEAD`
+          # with "fatal: bad revision" (Codex P2 on PR #14).
+          git fetch --no-tags origin "${{ github.event.pull_request.head.sha }}"
 
       - name: Resolve diff refs
         shell: bash

--- a/scripts/check-feature-memory.mjs
+++ b/scripts/check-feature-memory.mjs
@@ -85,10 +85,41 @@ for (const file of changedFiles) {
   featureIds.add(match[1]);
 }
 
-const hasCompleteFeatureMemory = (featureId) =>
-  existsSync(resolve(repoRoot, "specs", featureId, "spec.md")) &&
-  existsSync(resolve(repoRoot, "specs", featureId, "plan.md")) &&
-  existsSync(resolve(repoRoot, "specs", featureId, "tasks.md"));
+// In CI / pre-push the script runs from a checkout of the trusted base
+// branch (see specs/011-pipeline-gate-trusted-base), so `existsSync`
+// against the working tree would miss specs added in the PR head. We
+// probe the PR head ref via `git cat-file -e <ref>:<path>` instead —
+// it is a non-executing existence check that does not run any hooks
+// or filters from the PR's tree. The `--worktree` mode keeps the
+// filesystem probe because it is meant to validate uncommitted local
+// changes that have no ref to interrogate.
+const hasFileAtRef = (ref, path) => {
+  try {
+    execFileSync("git", ["cat-file", "-e", `${ref}:${path}`], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const hasCompleteFeatureMemory = (featureId) => {
+  if (inspectWorktree) {
+    return (
+      existsSync(resolve(repoRoot, "specs", featureId, "spec.md")) &&
+      existsSync(resolve(repoRoot, "specs", featureId, "plan.md")) &&
+      existsSync(resolve(repoRoot, "specs", featureId, "tasks.md"))
+    );
+  }
+
+  return (
+    hasFileAtRef(headRef, `specs/${featureId}/spec.md`) &&
+    hasFileAtRef(headRef, `specs/${featureId}/plan.md`) &&
+    hasFileAtRef(headRef, `specs/${featureId}/tasks.md`)
+  );
+};
 
 const validFeature = [...featureIds].find(hasCompleteFeatureMemory);
 

--- a/specs/011-pipeline-gate-trusted-base/plan.md
+++ b/specs/011-pipeline-gate-trusted-base/plan.md
@@ -55,6 +55,15 @@ gate trust boundary. No renderer / action / data-layer changes.
 - Fetching by SHA (rather than by `refs/pull/N/head`) is the simplest
   shape: GitHub Actions resolves `github.event.pull_request.head.sha`
   for us and the SHA is verifiable.
+- **No `--depth` cap on the fetch** (Codex P2 on PR #14). The
+  trusted-base checkout already pulled `main`'s full history with
+  `fetch-depth: 0`, so an unbounded `git fetch origin <sha>` only
+  adds the PR-side commits down to the existing merge-base and
+  stops; bandwidth is bounded by the actual divergence. A fixed cap
+  like `--depth=200` would silently drop the merge-base for
+  long-lived PR branches (or branches with >cap commits since fork)
+  and break the diff with `fatal: bad revision` even on otherwise
+  valid PRs.
 
 ## Bootstrap caveat (deliberately accepted)
 

--- a/specs/011-pipeline-gate-trusted-base/plan.md
+++ b/specs/011-pipeline-gate-trusted-base/plan.md
@@ -1,0 +1,100 @@
+# 011 — plan
+
+## Approach
+
+Two workflow yml edits + one targeted script refactor, scoped to the
+gate trust boundary. No renderer / action / data-layer changes.
+
+## Files touched
+
+| file                               | change                                                                                                                                       |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.github/workflows/ai-review.yml`  | `actions/checkout` gains `ref: ${{ github.event.repository.default_branch }}`                                                                |
+| `.github/workflows/pr-guard.yml`   | `actions/checkout` switches to `ref: default_branch`; new `git fetch` step pulls the PR head SHA so `git diff` / `git cat-file` keep working |
+| `scripts/check-feature-memory.mjs` | `existsSync(specs/<id>/*.md)` replaced by `git cat-file -e <headRef>:<path>` for the ref-based mode; `--worktree` mode keeps the FS probe    |
+
+## Why pin checkout to `default_branch` and not e.g. a static `main`
+
+- `default_branch` is the runtime-provided property of the repository
+  itself (`github.event.repository.default_branch`), so a one-time
+  rename of the default branch (`main` → `trunk`, etc.) does not
+  silently turn the gate back into "checkout from PR head" via
+  fall-through. Hard-coding `main` would do exactly that.
+- The `inputs.ref ||` cascade in the previous yml was the actual
+  vulnerability root: it allowed a `workflow_dispatch` caller to
+  override the ref to anything, including a PR head, while still
+  presenting itself as the trusted gate. Removing the cascade
+  altogether is part of the fix; `default_branch` is the only
+  value the gate ever needs.
+
+## Why `git cat-file -e` over `existsSync`
+
+- The original filesystem probe was correct only because the workflow
+  used to checkout the PR head, so `repoRoot/specs/<id>/spec.md` was
+  the PR's own copy. After this PR, `repoRoot` points at `main`'s
+  tree, so a freshly-introduced `specs/<id>/` exists only inside the
+  PR's tree under the PR head SHA — it has no presence on disk.
+- `git cat-file -e <ref>:<path>` is a non-executing existence probe
+  against an arbitrary git ref. It is the canonical way to ask "does
+  this path exist in this commit?" without touching the working tree
+  or shelling out to anything that interprets file contents. It does
+  not run hooks, scripts, or `.gitattributes` filters that could be
+  weaponised by a malicious PR.
+- The probe has a small enough surface that we can keep both modes in
+  one script: ref-aware in CI / pre-push, FS-aware in `--worktree`
+  for pre-commit dry-runs against uncommitted local changes.
+
+## Why fetch the PR head SHA explicitly in `pr-guard.yml`
+
+- `actions/checkout` with `ref: default_branch` and `fetch-depth: 0`
+  fetches `main`'s history, but the PR head SHA is not yet on any
+  branch we track from `main`'s perspective.
+- Without an explicit `git fetch origin <head-sha>` step, the existing
+  `git diff --name-only "${BASE_REF}...${HEAD_REF}"` would die with
+  "fatal: bad revision" because `HEAD_REF` is unreachable.
+- Fetching by SHA (rather than by `refs/pull/N/head`) is the simplest
+  shape: GitHub Actions resolves `github.event.pull_request.head.sha`
+  for us and the SHA is verifiable.
+
+## Bootstrap caveat (deliberately accepted)
+
+- For _this_ PR's own CI runs, `pr-guard` will check out `main`'s
+  pre-fix `scripts/check-feature-memory.mjs`, which still uses
+  `existsSync` and therefore cannot see `specs/011/*.md` (which are
+  only present in the PR head's tree, not in `main`). The gate will
+  fail loudly. Same for `AI Review` if Codex objects to the
+  trust-boundary diff.
+- Neither check is required for merge in this repo's branch
+  protection today, so the maintainer can land the PR despite the red
+  marks. After merge, every subsequent PR runs the new ref-aware
+  script from `main` and the gate behaves normally.
+- This is the standard "you have to bootstrap a tightening change
+  through one PR that fails its own gate" pattern; mitigations
+  (cherry-picked dispatch on `main` ahead of time, or splitting into
+  two PRs) cost more than the single-PR red-light merge.
+
+## Tripwires
+
+- **Prettier.** Both yml files and the mjs script live under
+  `format:check` globs. Tabs / trailing whitespace / non-ASCII
+  surprises will fail `pnpm run ci`.
+- **Guard self-test.** Run `node scripts/check-feature-memory.mjs
+origin/main HEAD` after every edit pass to make sure the rewritten
+  script still passes the gate against this PR's own commits.
+- **Local pre-push hook.** It calls the same script in non-`--worktree`
+  mode. Verify it still exits 0 once the spec triad is committed.
+- **`workflow_dispatch` callers.** `pr-guard.yml` previously honored
+  `inputs.ref` so an operator could re-run the gate against an
+  arbitrary commit. Removing the cascade narrows that surface; if
+  anyone relied on it, they'll need to re-trigger via the standard
+  pull-request event instead.
+
+## Rollback
+
+- The yml ref-pin is idempotent and trivially revertible — drop the
+  `ref:` line from each workflow.
+- The script refactor is a self-contained block; reverting just that
+  function restores the old `existsSync` shape and the gate continues
+  to work _as long as_ the workflows still checkout from PR head. Do
+  not partial-revert (yml without script, or vice versa) — the
+  combinations leave the gate broken in opposite directions.

--- a/specs/011-pipeline-gate-trusted-base/spec.md
+++ b/specs/011-pipeline-gate-trusted-base/spec.md
@@ -1,0 +1,113 @@
+# 011 — pipeline gate runs from trusted base
+
+## Intent
+
+Close a P0-class supply-chain hole in the PR-driven CI pipeline: the
+gate-style workflows (`.github/workflows/ai-review.yml`,
+`.github/workflows/pr-guard.yml`) currently `actions/checkout` the PR's
+own head ref and then execute Node scripts (`scripts/ai-review-gate.mjs`,
+`scripts/resolve-pr-context.mjs`, `scripts/check-feature-memory.mjs`) out
+of that workspace. A contributor — including a fork — can edit any of
+those scripts inside the PR and the gate will dutifully run the patched
+version, neutralising every blocking rule (severity gate, feature-memory
+requirement, etc.) before the maintainer sees the diff.
+
+The same vulnerability class was found by Codex in the sibling
+`tone-of-voice` repo (PR #3) and is being ported across the family.
+`comet-contribution-graph` does not currently mark `AI Review` / `guard`
+as a required check in branch protection (see the audit table in the
+trigger session), but the gate scripts are wired the same way — the
+exposure exists the moment we tighten branch protection or someone
+reuses the gate output as a signal in another tool.
+
+The fix moves the workflow execution context to the trusted base branch
+(`main`) so that the gate code GitHub runs is always the version that
+already passed review on `main`, not whatever the PR head proposes.
+
+## Constraints
+
+- One PR; no functional renderer / action / script-policy changes
+  outside the gate scripts and the two affected workflow files.
+- Guard requires `specs/<id>/{spec,plan,tasks}.md` for any product-path
+  change (`.github/workflows/`, `scripts/`). This triad satisfies that.
+- The gate run on **this very PR** will fail PR Guard / AI Review,
+  because `main` still ships the pre-fix scripts at PR-open time and
+  none of those checks are required for merge in this repo today. That
+  trade-off is explicitly accepted (analogous to bootstrapping any CI
+  hardening change).
+- Local pre-push hook
+  (`.claude/hooks/check-feature-memory-on-push.sh`) and `pnpm run
+check:feature-memory` must keep working — both invoke
+  `node scripts/check-feature-memory.mjs origin/main HEAD` in a regular
+  working tree where the spec files are present in the committed
+  `HEAD` ref.
+
+## Scope
+
+### In scope
+
+- **`.github/workflows/ai-review.yml`** — pin the `actions/checkout`
+  step to the repository's default branch via
+  `ref: ${{ github.event.repository.default_branch }}`. The downstream
+  scripts (`resolve-pr-context.mjs`, `ai-review-gate.mjs`) are pure
+  GitHub-API clients keyed by `GITHUB_TOKEN` + `inputs.pr_number`; they
+  never read PR files from disk, so running them from `main` is
+  semantically a no-op for correctness and a hard win for trust.
+- **`.github/workflows/pr-guard.yml`** — same `ref:` switch on the
+  checkout step. Add a follow-up `git fetch` for the PR head SHA so
+  the existing
+  `git diff --name-only "${BASE_REF}...${HEAD_REF}"` invocation can
+  still reach both endpoints from the `main` tree.
+- **`scripts/check-feature-memory.mjs`** — replace the
+  `existsSync(repoRoot/specs/<id>/{spec,plan,tasks}.md)` filesystem
+  probe with `git cat-file -e <headRef>:<path>` so the gate (now
+  running from `main`) can validate spec files added in the PR's tree
+  without ever executing PR-controlled code. Keep the existing
+  filesystem probe for the explicit `--worktree` mode (used for
+  pre-commit dry runs against uncommitted changes), since there is no
+  ref to interrogate in that mode.
+
+### Out of scope (deferred to follow-up PRs)
+
+- **`pnpm install --frozen-lockfile` + `pnpm run check:repo`** at the
+  tail of `pr-guard.yml`. After this fix they run against `main`'s
+  tree, which means lockfile / baseline regressions introduced by a
+  PR are no longer caught here. The post-merge `ci.yml` workflow runs
+  the full `pnpm run ci` against `main`, so they will surface within
+  one merge cycle, but pre-merge coverage drops. Restoring per-PR
+  validation requires either a two-checkout pattern (a separate
+  `path: .trusted` checkout alongside a sandboxed PR checkout) or a
+  refactor that lifts `check:repo` and the lockfile assertion into
+  ref-aware scripts. Tracked separately.
+- **`scripts/ai-review-gate.mjs` / `scripts/resolve-pr-context.mjs`
+  hardening.** These already only touch the GitHub API; this PR
+  delivers the trust boundary at the workflow level and does not
+  modify them.
+- **Sibling repos.** `pallete-maker`, `dreamboard`, `capsule-zero`,
+  `vb-influencer` carry the same vulnerability shape per the audit
+  table; the port to each lives in its own PR in its own repository.
+
+## Acceptance
+
+1. `.github/workflows/ai-review.yml` checkout step has
+   `ref: ${{ github.event.repository.default_branch }}`.
+2. `.github/workflows/pr-guard.yml` checkout step has
+   `ref: ${{ github.event.repository.default_branch }}`, the previous
+   `inputs.ref || head.sha || github.sha` cascade is gone, and a
+   follow-up step fetches the PR head SHA so `git diff` and
+   `git cat-file` can reach it.
+3. `scripts/check-feature-memory.mjs` no longer calls `existsSync` on
+   `specs/<id>/*.md` outside the `--worktree` branch; the ref-based
+   path uses `git cat-file -e <headRef>:<path>` instead.
+4. `node scripts/check-feature-memory.mjs origin/main HEAD` passes
+   locally (this PR's own spec triad must satisfy the gate).
+5. `pnpm run ci` is green locally — in particular `format:check`
+   covers `.github/workflows/*.yml` and `scripts/**/*.mjs`, so all
+   touched files must be prettier-clean.
+
+## Post-merge verification
+
+- After merge, watch the next unrelated PR's `pr-guard` and
+  `AI Review` runs land green to confirm the bootstrap is over.
+- Spot-check the run logs for `ai-review.yml` to confirm the checkout
+  step shows it grabbed `main`, not the PR head.

--- a/specs/011-pipeline-gate-trusted-base/tasks.md
+++ b/specs/011-pipeline-gate-trusted-base/tasks.md
@@ -1,0 +1,44 @@
+# 011 — tasks
+
+## Pre-merge (this PR)
+
+- [ ] T1. Branch `claude/ecstatic-shannon-d60246` (already created by
+      worktree); spec triad written under
+      `specs/011-pipeline-gate-trusted-base/`.
+- [ ] T2. Edit `.github/workflows/ai-review.yml` — add
+      `ref: ${{ github.event.repository.default_branch }}` to the
+      `actions/checkout` step.
+- [ ] T3. Edit `.github/workflows/pr-guard.yml` — replace the
+      `inputs.ref || head.sha || github.sha` cascade with
+      `ref: ${{ github.event.repository.default_branch }}`. Add a
+      `git fetch origin "${{ github.event.pull_request.head.sha }}"`
+      step gated on `github.event_name == 'pull_request'` so the diff
+      and cat-file probes can reach the PR head.
+- [ ] T4. Refactor `scripts/check-feature-memory.mjs`:
+      replace `existsSync(...specs/<id>/*.md)` with a
+      `git cat-file -e <headRef>:<path>` helper for the ref-based
+      mode. Keep `existsSync` only inside the `--worktree` branch.
+- [ ] T5. Run `node scripts/check-feature-memory.mjs origin/main HEAD`
+      locally — expect green.
+- [ ] T6. Run `pnpm run ci` locally — expect green (in particular
+      `format:check` and `test`).
+- [ ] T7. Commit with `fix(ci):` prefix, subject ≤72 chars, no body.
+- [ ] T8. Push branch.
+- [ ] T9. Open PR. Body: 1–2 sentences referencing this spec, plus an
+      explicit note that the PR's own `pr-guard` / `AI Review` run is
+      expected to fail because `main` still serves the pre-fix
+      scripts. Cite the audit table for context.
+- [ ] T10. Post `@codex review` inline via `gh pr comment` per project
+      memory (`feedback_codex_human_trigger`). Codex review will run
+      against `main`'s pre-fix scripts and may fail; that is fine.
+- [ ] T11. Merge via `gh pr merge --squash` (no `--delete-branch`
+      from worktree — project memory
+      `feedback_gh_pr_merge_delete_branch_worktree`).
+
+## Post-merge
+
+- [ ] T12. Inspect the next unrelated PR's `pr-guard` and `AI Review`
+      runs to confirm the new ref-aware path is healthy.
+- [ ] T13. Open follow-up issues / specs for the deferred items
+      (lockfile + `check:repo` PR validation; cross-repo port to
+      `pallete-maker` if the maintainer wants it).


### PR DESCRIPTION
## Summary

- **P0 supply-chain fix.** `ai-review.yml` and `pr-guard.yml` previously
  `actions/checkout`-ed the PR's own head ref and then ran the
  `scripts/*.mjs` gate code out of that workspace, so a contributor (or
  fork) could rewrite the gate inside their PR and silently neutralise
  it. Both workflows now check out the repository's
  `default_branch`, so the gate code GitHub executes is always the
  version that already passed review on `main`.
- **`scripts/check-feature-memory.mjs`** updated to probe spec files
  through `git cat-file -e <headRef>:<path>` instead of
  `existsSync` against the local working tree. Required because, after
  the workflow ref-pin, the working tree shows `main`'s content and
  freshly-introduced specs only exist in the PR head ref. Local
  `--worktree` mode keeps the FS probe for uncommitted dry-runs.
- **Cross-repo port** of the same fix being landed for `tone-of-voice`
  PR #3. `pallete-maker`, `dreamboard`, `capsule-zero`, `vb-influencer`
  share the vulnerability shape but each gets its own port PR.
- **Full context** in
  [specs/011-pipeline-gate-trusted-base/](specs/011-pipeline-gate-trusted-base/).
  The deferred scope (pre-merge `pnpm install --frozen-lockfile` +
  `pnpm run check:repo` no longer validate the PR's tree) is documented
  there and tracked separately.

## Bootstrap caveat (expected red marks on this PR)

`pr-guard` and `AI Review` for **this very PR** are expected to fail:
GitHub serves the pre-fix `scripts/check-feature-memory.mjs` from
`main`, which still uses `existsSync` and therefore cannot see
`specs/011/*.md` (only present in the PR head). Neither check is
required for merge in this repo's branch protection today, so this PR
is intentionally landed despite the red marks. Every subsequent PR
runs the new ref-aware script from `main` and the gate behaves
normally.

## Test plan

- [x] `pnpm run format:check` clean (prettier covers the touched yml +
      mjs + new spec triad).
- [x] `pnpm run ci` green locally (91/91 tests pass; check:repo,
      check:html, check:js, check:ts, build, build:action, check:dist,
      format:check, test).
- [x] `node scripts/check-feature-memory.mjs origin/main HEAD` exits 0
      (proves the new `git cat-file` probe finds this PR's own spec
      triad).
- [ ] Post-merge: confirm the next unrelated PR's `pr-guard` and
      `AI Review` runs land green.