### PR TITLE
docs: use @ syntax for CLAUDE.md doc references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,9 @@ Skip the proposal for trivial tasks (rename, one-line fix, quick question, fast 
 
 ## Documentation
 
-- Process constitution: `.specify/memory/constitution.md`
-- Docs map: `docs_comet/README.md`
-- Product idea: `docs_comet/project-idea.md`
+- Process constitution: @.specify/memory/constitution.md
+- Docs map: @docs_comet/README.md
+- Product idea: @docs_comet/project-idea.md
 - Frontend: `docs_comet/project/frontend/frontend-docs.md`
 - Orchestration: `docs_comet/project/devops/ai-orchestration-protocol.md`
 - PR loop: `docs_comet/project/devops/ai-pr-workflow.md`


### PR DESCRIPTION
## Summary
- Convert top documentation references in CLAUDE.md to `@` syntax (constitution, docs map, project idea)
- `@path` makes Claude Code auto-load file content at session start (vs. backtick paths, which require an explicit Read)

## Why
Per Anthropic recommendation. Plain backtick paths are findable but not auto-loaded — the agent has to explicitly Read them and may skip context the user intended to be foundational.

## Scope
Only top 3 most critical paths converted. Long documentation indexes intentionally remain as backticks (avoid bloating session context).

## Test plan
- [ ] baseline-checks + guard + AI Review pass
- [ ] No broken paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)